### PR TITLE
Add ICT log parser and Supabase ingest pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ SHEET_ID=your-google-sheet-id
 
 # Supabase (required by the ingest pipeline)
 SUPABASE_URL=https://your-project-ref.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key   # service role, NOT the anon key
+# Use the service role key, NOT the anon key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Ingest authentication — arbitrary shared secret; must match apiSecret in ict-ingest.config.json
 INGEST_SECRET=your-ingest-secret

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ SHEET_ID=your-google-sheet-id
 # Supabase (required by the ingest pipeline)
 SUPABASE_URL=https://your-project-ref.supabase.co
 # Use the service role key, NOT the anon key
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_SERVICE_KEY=your-service-role-key
 
 # Ingest authentication — arbitrary shared secret; must match apiSecret in ict-ingest.config.json
 INGEST_SECRET=your-ingest-secret

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Google Sheets integration (required by the viewer)
+SHEET_ID=your-google-sheet-id
+
+# Supabase (required by the ingest pipeline)
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key   # service role, NOT the anon key
+
+# Ingest authentication — arbitrary shared secret; must match apiSecret in ict-ingest.config.json
+INGEST_SECRET=your-ingest-secret

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ict-data-viewer",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.99.1",
         "chart.js": "^4.5.1",
         "next": "^16.1.6",
         "react": "^19.2.4",
@@ -2232,6 +2233,86 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.1.tgz",
+      "integrity": "sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.1.tgz",
+      "integrity": "sha512-WQE62W5geYImCO4jzFxCk/avnK7JmOdtqu2eiPz3zOaNiIJajNRSAwMMDgEGd2EMs+sUVYj1LfBjfmW3EzHgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.1.tgz",
+      "integrity": "sha512-gtw2ibJrADvfqrpUWXGNlrYUvxttF4WVWfPpTFKOb2IRj7B6YRWMDgcrYqIuD4ZEabK4m6YKQCCGy6clgf1lPA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.1.tgz",
+      "integrity": "sha512-9EDdy/5wOseGFqxW88ShV9JMRhm7f+9JGY5x+LqT8c7R0X1CTLwg5qie8FiBWcXTZ+68yYxVWunI+7W4FhkWOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.1.tgz",
+      "integrity": "sha512-mf7zPfqofI62SOoyQJeNUVxe72E4rQsbWim6lTDPeLu3lHija/cP5utlQADGrjeTgOUN6znx/rWn7SjrETP1dw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.1.tgz",
+      "integrity": "sha512-5MRoYD9ffXq8F6a036dm65YoSHisC3by/d22mauKE99Vrwf792KxYIIr/iqCX7E4hkuugbPZ5EGYHTB7MKy6Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.1",
+        "@supabase/functions-js": "2.99.1",
+        "@supabase/postgrest-js": "2.99.1",
+        "@supabase/realtime-js": "2.99.1",
+        "@supabase/storage-js": "2.99.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2505,11 +2586,16 @@
       "version": "25.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.11",
@@ -2544,6 +2630,15 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5619,6 +5714,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -9838,7 +9942,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -10235,7 +10338,6 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.99.1",
     "chart.js": "^4.5.1",
     "next": "^16.1.6",
     "react": "^19.2.4",

--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   process.env.SUPABASE_URL = 'https://example.supabase.co';
-  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+  process.env.SUPABASE_SERVICE_KEY = 'test-key';
 
   // Default happy path:
   // products upsert

--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -167,7 +167,13 @@ describe('upsertTest', () => {
   });
 
   it('throws when SUPABASE_URL is missing', async () => {
+    // The module-level singleton means getClient() only checks env vars on the
+    // first call. Use isolateModulesAsync to load a fresh module instance with
+    // no cached client so the env var check is exercised.
     delete process.env.SUPABASE_URL;
-    await expect(upsertTest(PARSED)).rejects.toThrow('SUPABASE_URL');
+    await jest.isolateModulesAsync(async () => {
+      const { upsertTest: freshUpsert } = await import('@/lib/ict-db');
+      await expect(freshUpsert(PARSED)).rejects.toThrow('SUPABASE_URL');
+    });
   });
 });

--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -1,0 +1,173 @@
+/**
+ * ict-db.test.ts
+ *
+ * All Supabase calls are fully mocked — no real DB is touched.
+ */
+
+// Must mock before importing ict-db so createClient returns our mock
+const mockSelect = jest.fn();
+const mockMaybeSingle = jest.fn();
+const mockUpsert = jest.fn();
+const mockInsert = jest.fn();
+
+// Build a chainable mock that always returns the same shape
+function makeFrom(overrides: Record<string, jest.Mock> = {}) {
+  return {
+    upsert: overrides.upsert ?? mockUpsert,
+    insert: overrides.insert ?? mockInsert,
+    select: overrides.select ?? mockSelect,
+    maybeSingle: overrides.maybeSingle ?? mockMaybeSingle,
+  };
+}
+
+const mockFrom = jest.fn();
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+import { upsertTest } from '@/lib/ict-db';
+import type { ParsedTest } from '@/lib/ict-parser';
+
+const PARSED: ParsedTest = {
+  board_id: '465136J+2609F808HH',
+  product_id: '465136J',
+  family: 'C2-ROT41',
+  part_number: '8215911',
+  revision: '13',
+  mac_address: 'A8698C613296',
+  result: 'PASS',
+  start_time: new Date('2026-03-12T13:10:48Z'),
+  end_time: new Date('2026-03-12T13:12:13Z'),
+  operator_id: '102059',
+  tester: 'TESTER-2',
+  fixture_id: 'FxSJ_WW3423',
+  testplan: 'Released-04-04-2025',
+  platform: 'Agilent3070 Rev:8.30',
+  errors: [
+    {
+      component: 'c314_1_c',
+      component_value: '1UF',
+      part_number: '110-5581-01',
+      measured_raw: '0.78327u',
+      measured: 7.8327e-7,
+      nominal_raw: '1.0000u',
+      nominal: 1e-6,
+      high_limit_raw: '1.2000u',
+      high_limit: 1.2e-6,
+      low_limit_raw: '0.80000u',
+      low_limit: 8e-7,
+      unit: 'FARADS',
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+  // Default happy path:
+  // products upsert
+  const productsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+  // boards upsert
+  const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+  // tests upsert — chain: .upsert().select().maybeSingle()
+  const maybeSingleFn = jest.fn().mockResolvedValue({ data: { id: 42 }, error: null });
+  const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
+  const testsUpsertFn = jest.fn().mockReturnValue({ select: selectFn });
+  const testsChain = { upsert: testsUpsertFn };
+  // test_errors insert
+  const errorsChain = { insert: jest.fn().mockResolvedValue({ error: null }) };
+
+  mockFrom
+    .mockReturnValueOnce(productsChain)
+    .mockReturnValueOnce(boardsChain)
+    .mockReturnValueOnce(testsChain)
+    .mockReturnValueOnce(errorsChain);
+});
+
+describe('upsertTest', () => {
+  it('calls from("products").upsert with correct fields', async () => {
+    await upsertTest(PARSED);
+    const productsCall = mockFrom.mock.calls[0][0];
+    expect(productsCall).toBe('products');
+    const upsertArg = mockFrom.mock.results[0].value.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({
+      id: '465136J',
+      part_number: '8215911',
+      revision: '13',
+      family: 'C2-ROT41',
+    });
+  });
+
+  it('calls from("boards").upsert with correct fields', async () => {
+    await upsertTest(PARSED);
+    expect(mockFrom.mock.calls[1][0]).toBe('boards');
+    const upsertArg = mockFrom.mock.results[1].value.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({
+      id: '465136J+2609F808HH',
+      product_id: '465136J',
+      mac_address: 'A8698C613296',
+    });
+  });
+
+  it('calls from("tests").upsert with correct fields', async () => {
+    await upsertTest(PARSED);
+    expect(mockFrom.mock.calls[2][0]).toBe('tests');
+    const upsertArg = mockFrom.mock.results[2].value.upsert.mock.calls[0][0];
+    expect(upsertArg).toMatchObject({
+      board_id: '465136J+2609F808HH',
+      result: 'PASS',
+      operator_id: '102059',
+    });
+  });
+
+  it('calls from("test_errors").insert when test is new', async () => {
+    await upsertTest(PARSED);
+    expect(mockFrom.mock.calls[3][0]).toBe('test_errors');
+    const insertArg = mockFrom.mock.results[3].value.insert.mock.calls[0][0];
+    expect(insertArg).toHaveLength(1);
+    expect(insertArg[0]).toMatchObject({
+      test_id: 42,
+      component: 'c314_1_c',
+      unit: 'FARADS',
+    });
+  });
+
+  it('skips test_errors insert when test already existed (ignoreDuplicates → null)', async () => {
+    // Re-wire: tests returns null (already existed)
+    const productsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+    const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+    const maybeSingleFn = jest.fn().mockResolvedValue({ data: null, error: null });
+    const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
+    const testsUpsertFn = jest.fn().mockReturnValue({ select: selectFn });
+    const testsChain = { upsert: testsUpsertFn };
+
+    mockFrom.mockReset();
+    mockFrom
+      .mockReturnValueOnce(productsChain)
+      .mockReturnValueOnce(boardsChain)
+      .mockReturnValueOnce(testsChain);
+
+    await upsertTest(PARSED);
+    // from() should only have been called 3 times (no test_errors call)
+    expect(mockFrom).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws when products upsert fails', async () => {
+    mockFrom.mockReset();
+    mockFrom.mockReturnValueOnce({
+      upsert: jest.fn().mockResolvedValue({ error: { message: 'DB down' } }),
+    });
+    await expect(upsertTest(PARSED)).rejects.toThrow('products upsert failed: DB down');
+  });
+
+  it('throws when SUPABASE_URL is missing', async () => {
+    delete process.env.SUPABASE_URL;
+    await expect(upsertTest(PARSED)).rejects.toThrow('SUPABASE_URL');
+  });
+});

--- a/src/__tests__/ict-parser.test.ts
+++ b/src/__tests__/ict-parser.test.ts
@@ -1,0 +1,303 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseLog, parseSiValue, parseTimestamp } from '@/lib/ict-parser';
+
+const SAMPLE_DIR = path.join(__dirname, '..', 'pipeline', 'docs', 'sample-logs');
+
+function readSample(filename: string): string {
+  return fs.readFileSync(path.join(SAMPLE_DIR, filename), 'utf8');
+}
+
+// Pre-load all 4 sample files
+const log808HH = readSample('465136J_2609F808HH.log');   // PASS, 1 error, numeric operator
+const log8092F = readSample('465136J_2609F8092F.log');   // PASS, 2 errors, µF + Ω
+const log808RM = readSample('465136J_2609F808RM.log');   // PASS, 2 errors, alphanumeric operator
+const log8019P = readSample('465136J_2611F8019P.log');   // FAIL, 8 unique components
+
+// ---------------------------------------------------------------------------
+// parseSiValue
+// ---------------------------------------------------------------------------
+describe('parseSiValue', () => {
+  it('converts µ suffix (microfarads)', () => {
+    expect(parseSiValue('0.78327u')).toBeCloseTo(0.78327e-6);
+  });
+
+  it('converts p suffix (picofarads)', () => {
+    expect(parseSiValue('233.26p')).toBeCloseTo(233.26e-12);
+  });
+
+  it('converts k suffix (kilohms)', () => {
+    expect(parseSiValue('20.000k')).toBeCloseTo(20000);
+  });
+
+  it('converts M suffix (megaohms)', () => {
+    expect(parseSiValue('1.5612M')).toBeCloseTo(1561200);
+  });
+
+  it('handles plain number (no suffix)', () => {
+    expect(parseSiValue('10.942')).toBeCloseTo(10.942);
+  });
+
+  it('returns null for non-numeric input', () => {
+    expect(parseSiValue('N/A')).toBeNull();
+    expect(parseSiValue('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTimestamp
+// ---------------------------------------------------------------------------
+describe('parseTimestamp', () => {
+  it('parses YYMMDDHHMMSS to UTC Date', () => {
+    const d = parseTimestamp('260311134729');
+    expect(d.getUTCFullYear()).toBe(2026);
+    expect(d.getUTCMonth()).toBe(2); // March = 2 (0-indexed)
+    expect(d.getUTCDate()).toBe(11);
+    expect(d.getUTCHours()).toBe(13);
+    expect(d.getUTCMinutes()).toBe(47);
+    expect(d.getUTCSeconds()).toBe(29);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — all 4 sample files parse without throwing
+// ---------------------------------------------------------------------------
+describe('parseLog — smoke tests (all 4 sample files)', () => {
+  it('465136J_2609F808HH.log parses without throwing', () => {
+    expect(() => parseLog('465136J_2609F808HH.log', log808HH)).not.toThrow();
+  });
+
+  it('465136J_2609F8092F.log parses without throwing', () => {
+    expect(() => parseLog('465136J_2609F8092F.log', log8092F)).not.toThrow();
+  });
+
+  it('465136J_2609F808RM.log parses without throwing', () => {
+    expect(() => parseLog('465136J_2609F808RM.log', log808RM)).not.toThrow();
+  });
+
+  it('465136J_2611F8019P.log parses without throwing', () => {
+    expect(() => parseLog('465136J_2611F8019P.log', log8019P)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — board_id / product_id extraction
+// ---------------------------------------------------------------------------
+describe('parseLog — identifiers', () => {
+  it('replaces first underscore with + to form board_id', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.board_id).toBe('465136J+2609F808HH');
+  });
+
+  it('extracts product_id as the part before +', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.product_id).toBe('465136J');
+  });
+
+  it('board_id from FAIL log', () => {
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    expect(r.board_id).toBe('465136J+2611F8019P');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — metadata fields
+// ---------------------------------------------------------------------------
+describe('parseLog — metadata', () => {
+  it('extracts family', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.family).toBe('C2-ROT41');
+  });
+
+  it('extracts part_number and revision from P/N field', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.part_number).toBe('8215911');
+    expect(r.revision).toBe('13');
+  });
+
+  it('extracts testplan', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.testplan).toBe('Released-04-04-2025');
+  });
+
+  it('extracts platform', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.platform).toBe('Agilent3070 Rev:8.30');
+  });
+
+  it('extracts mac_address', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.mac_address).toBe('A8698C613296');
+  });
+
+  it('extracts tester', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.tester).toBe('TESTER-2');
+  });
+
+  it('extracts fixture_id', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.fixture_id).toBe('FxSJ_WW3423');
+  });
+
+  it('handles numeric operator_id (102059)', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.operator_id).toBe('102059');
+  });
+
+  it('handles alphanumeric operator_id (JT1227)', () => {
+    const r = parseLog('465136J_2609F808RM.log', log808RM);
+    expect(r.operator_id).toBe('JT1227');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — timestamps
+// ---------------------------------------------------------------------------
+describe('parseLog — timestamps', () => {
+  it('parses start_time from ST field', () => {
+    // ST:260312131048 → 2026-03-12 13:10:48 UTC
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.start_time.getUTCFullYear()).toBe(2026);
+    expect(r.start_time.getUTCMonth()).toBe(2);
+    expect(r.start_time.getUTCDate()).toBe(12);
+    expect(r.start_time.getUTCHours()).toBe(13);
+    expect(r.start_time.getUTCMinutes()).toBe(10);
+    expect(r.start_time.getUTCSeconds()).toBe(48);
+  });
+
+  it('parses end_time from ET field', () => {
+    // ET:260312131213 → 2026-03-12 13:12:13 UTC
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.end_time.getUTCHours()).toBe(13);
+    expect(r.end_time.getUTCMinutes()).toBe(12);
+    expect(r.end_time.getUTCSeconds()).toBe(13);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — result
+// ---------------------------------------------------------------------------
+describe('parseLog — result', () => {
+  it('parses PASS result from 808HH', () => {
+    expect(parseLog('465136J_2609F808HH.log', log808HH).result).toBe('PASS');
+  });
+
+  it('parses PASS result from 8092F', () => {
+    expect(parseLog('465136J_2609F8092F.log', log8092F).result).toBe('PASS');
+  });
+
+  it('parses PASS result from 808RM', () => {
+    expect(parseLog('465136J_2609F808RM.log', log808RM).result).toBe('PASS');
+  });
+
+  it('parses FAIL result from 2611F8019P', () => {
+    expect(parseLog('465136J_2611F8019P.log', log8019P).result).toBe('FAIL');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — error deduplication
+// ---------------------------------------------------------------------------
+describe('parseLog — error deduplication', () => {
+  it('808HH: each run appears twice but only 1 unique error is stored', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0].component).toBe('c314_1_c');
+  });
+
+  it('8092F: 9 unique error components', () => {
+    const r = parseLog('465136J_2609F8092F.log', log8092F);
+    expect(r.errors).toHaveLength(9);
+    const components = r.errors.map((e) => e.component);
+    expect(components).toContain('c314_1_c');
+    expect(components).toContain('r503');
+    expect(components).toContain('r206_2_c');
+    expect(components).toContain('r834');
+    expect(components).toContain('r411_2_c');
+  });
+
+  it('808RM: 2 unique resistor errors', () => {
+    const r = parseLog('465136J_2609F808RM.log', log808RM);
+    expect(r.errors).toHaveLength(2);
+    const components = r.errors.map((e) => e.component);
+    expect(components).toContain('r320_1_c');
+    expect(components).toContain('r7108_2_c');
+  });
+
+  it('2611F8019P: 8 unique component errors across multiple retry runs', () => {
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    expect(r.errors).toHaveLength(8);
+    const components = r.errors.map((e) => e.component);
+    expect(components).toContain('c103_p');
+    expect(components).toContain('c407_c');
+    expect(components).toContain('r7108_2_c');
+    expect(components).toContain('r503');
+    expect(components).toContain('r210_2_c');
+    expect(components).toContain('r625');
+    expect(components).toContain('r7308_2_c');
+    expect(components).toContain('r421_2_c');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLog — error field values
+// ---------------------------------------------------------------------------
+describe('parseLog — error field values', () => {
+  it('stores component_value and part_number', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.errors[0].component_value).toBe('1UF');
+    expect(r.errors[0].part_number).toBe('110-5581-01');
+  });
+
+  it('stores measured_raw and unit for capacitor (FARADS)', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.errors[0].measured_raw).toBe('0.78327u');
+    expect(r.errors[0].unit).toBe('FARADS');
+  });
+
+  it('converts µF to SI base unit (Farads)', () => {
+    const r = parseLog('465136J_2609F808HH.log', log808HH);
+    expect(r.errors[0].measured).toBeCloseTo(0.78327e-6);
+  });
+
+  it('converts pF to SI base unit (Farads) — c407_c in 2611F8019P', () => {
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    const c407 = r.errors.find((e) => e.component === 'c407_c')!;
+    expect(c407.measured_raw).toBe('233.26p');
+    expect(c407.measured).toBeCloseTo(233.26e-12);
+    expect(c407.unit).toBe('FARADS');
+  });
+
+  it('converts kΩ to SI base unit (Ohms) — r625 in 2611F8019P', () => {
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    const r625 = r.errors.find((e) => e.component === 'r625')!;
+    expect(r625.nominal_raw).toBe('20.000k');
+    expect(r625.nominal).toBeCloseTo(20000);
+    expect(r625.unit).toBe('OHMS');
+  });
+
+  it('converts MΩ to SI base unit (Ohms) — r625 measured', () => {
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    const r625 = r.errors.find((e) => e.component === 'r625')!;
+    expect(r625.measured_raw).toBe('1.5612M');
+    expect(r625.measured).toBeCloseTo(1561200);
+  });
+
+  it('parses plain Ω value (no suffix) — r503 in 8092F', () => {
+    const r = parseLog('465136J_2609F8092F.log', log8092F);
+    const r503 = r.errors.find((e) => e.component === 'r503')!;
+    expect(r503.measured_raw).toBe('10.942');
+    expect(r503.measured).toBeCloseTo(10.942);
+    expect(r503.unit).toBe('OHMS');
+  });
+
+  it('skips DEVICES IN PARALLEL hint lines — r625 is an error, not a parallel note', () => {
+    // r625 should appear in errors; the "DEVICES IN PARALLEL / c640 220p" note should NOT
+    const r = parseLog('465136J_2611F8019P.log', log8019P);
+    const components = r.errors.map((e) => e.component);
+    expect(components).toContain('r625');
+    expect(components).not.toContain('c640');
+    expect(components).not.toContain('devices in parallel');
+  });
+});

--- a/src/__tests__/ingest-route.test.ts
+++ b/src/__tests__/ingest-route.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment node
+ *
+ * ingest-route.test.ts
+ *
+ * Tests for POST /api/ingest.
+ * Both the parser and DB layer are fully mocked — no real I/O.
+ */
+
+// Mock ict-parser and ict-db before importing the route
+jest.mock('@/lib/ict-parser', () => ({
+  parseLog: jest.fn(),
+}));
+
+jest.mock('@/lib/ict-db', () => ({
+  upsertTest: jest.fn(),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/ingest/route';
+import { parseLog } from '@/lib/ict-parser';
+import { upsertTest } from '@/lib/ict-db';
+
+const mockParseLog = parseLog as jest.Mock;
+const mockUpsertTest = upsertTest as jest.Mock;
+
+const PARSED_RESULT = {
+  board_id: '465136J+2609F808HH',
+  product_id: '465136J',
+  result: 'PASS' as const,
+  family: 'C2-ROT41',
+  part_number: '8215911',
+  revision: '13',
+  mac_address: '',
+  start_time: new Date(),
+  end_time: new Date(),
+  operator_id: '',
+  tester: '',
+  fixture_id: '',
+  testplan: '',
+  platform: '',
+  errors: [],
+};
+
+function makeRequest(body: unknown, secret: string | null = 'test-secret'): NextRequest {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (secret !== null) headers['x-ingest-secret'] = secret;
+  return new NextRequest('http://localhost/api/ingest', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.INGEST_SECRET = 'test-secret';
+  mockParseLog.mockReturnValue(PARSED_RESULT);
+  mockUpsertTest.mockResolvedValue(undefined);
+});
+
+describe('POST /api/ingest', () => {
+  it('returns 401 when x-ingest-secret header is missing', async () => {
+    const res = await POST(makeRequest({ filename: 'a.log', content: 'x' }, null));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 401 when x-ingest-secret is wrong', async () => {
+    const res = await POST(makeRequest({ filename: 'a.log', content: 'x' }, 'wrong'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for non-JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/ingest', {
+      method: 'POST',
+      headers: { 'x-ingest-secret': 'test-secret', 'content-type': 'text/plain' },
+      body: 'not json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when filename is missing from body', async () => {
+    const res = await POST(makeRequest({ content: 'x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when content is missing from body', async () => {
+    const res = await POST(makeRequest({ filename: 'a.log' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with board_id and result on success', async () => {
+    const res = await POST(makeRequest({ filename: '465136J_2609F808HH.log', content: 'data' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, board_id: '465136J+2609F808HH', result: 'PASS' });
+  });
+
+  it('calls parseLog with filename and content', async () => {
+    await POST(makeRequest({ filename: 'test.log', content: 'raw content' }));
+    expect(mockParseLog).toHaveBeenCalledWith('test.log', 'raw content');
+  });
+
+  it('calls upsertTest with parsed result', async () => {
+    await POST(makeRequest({ filename: 'test.log', content: 'raw' }));
+    expect(mockUpsertTest).toHaveBeenCalledWith(PARSED_RESULT);
+  });
+
+  it('returns 500 when parseLog throws', async () => {
+    mockParseLog.mockImplementation(() => { throw new Error('bad format'); });
+    const res = await POST(makeRequest({ filename: 'bad.log', content: 'garbage' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/bad format/);
+  });
+
+  it('returns 500 when upsertTest rejects', async () => {
+    mockUpsertTest.mockRejectedValue(new Error('DB connection failed'));
+    const res = await POST(makeRequest({ filename: 'test.log', content: 'data' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/DB connection failed/);
+  });
+});

--- a/src/__tests__/ingest-route.test.ts
+++ b/src/__tests__/ingest-route.test.ts
@@ -3,7 +3,7 @@
  *
  * ingest-route.test.ts
  *
- * Tests for POST /api/ingest.
+ * Tests for POST /api/ingest (batched).
  * Both the parser and DB layer are fully mocked — no real I/O.
  */
 
@@ -42,6 +42,14 @@ const PARSED_RESULT = {
   errors: [],
 };
 
+// Two-file batch used across most tests
+const BATCH = {
+  files: [
+    { filename: 'a.log', content: 'data1' },
+    { filename: 'b.log', content: 'data2' },
+  ],
+};
+
 function makeRequest(body: unknown, secret: string | null = 'test-secret'): NextRequest {
   const headers: Record<string, string> = { 'content-type': 'application/json' };
   if (secret !== null) headers['x-ingest-secret'] = secret;
@@ -60,68 +68,99 @@ beforeEach(() => {
 });
 
 describe('POST /api/ingest', () => {
+  // --- auth ---
   it('returns 401 when x-ingest-secret header is missing', async () => {
-    const res = await POST(makeRequest({ filename: 'a.log', content: 'x' }, null));
+    const res = await POST(makeRequest(BATCH, null));
     expect(res.status).toBe(401);
-    const body = await res.json();
-    expect(body).toHaveProperty('error');
+    expect(await res.json()).toHaveProperty('error');
   });
 
   it('returns 401 when x-ingest-secret is wrong', async () => {
-    const res = await POST(makeRequest({ filename: 'a.log', content: 'x' }, 'wrong'));
+    const res = await POST(makeRequest(BATCH, 'wrong'));
     expect(res.status).toBe(401);
   });
 
+  // --- body validation ---
   it('returns 400 for non-JSON body', async () => {
     const req = new NextRequest('http://localhost/api/ingest', {
       method: 'POST',
       headers: { 'x-ingest-secret': 'test-secret', 'content-type': 'text/plain' },
       body: 'not json',
     });
-    const res = await POST(req);
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it('returns 400 when files array is missing (old single-file shape)', async () => {
+    const res = await POST(makeRequest({ filename: 'a.log', content: 'x' }));
     expect(res.status).toBe(400);
   });
 
-  it('returns 400 when filename is missing from body', async () => {
-    const res = await POST(makeRequest({ content: 'x' }));
+  it('returns 400 when a file entry is missing filename', async () => {
+    const res = await POST(makeRequest({ files: [{ content: 'x' }] }));
     expect(res.status).toBe(400);
   });
 
-  it('returns 400 when content is missing from body', async () => {
-    const res = await POST(makeRequest({ filename: 'a.log' }));
+  it('returns 400 when a file entry is missing content', async () => {
+    const res = await POST(makeRequest({ files: [{ filename: 'a.log' }] }));
     expect(res.status).toBe(400);
   });
 
-  it('returns 200 with board_id and result on success', async () => {
-    const res = await POST(makeRequest({ filename: '465136J_2609F808HH.log', content: 'data' }));
+  // --- happy path ---
+  it('returns 200 with processed count and empty failed on full success', async () => {
+    const res = await POST(makeRequest(BATCH));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ processed: 2, failed: [] });
+  });
+
+  it('calls parseLog and upsertTest for each file in the batch', async () => {
+    await POST(makeRequest(BATCH));
+    expect(mockParseLog).toHaveBeenCalledTimes(2);
+    expect(mockParseLog).toHaveBeenCalledWith('a.log', 'data1');
+    expect(mockParseLog).toHaveBeenCalledWith('b.log', 'data2');
+    expect(mockUpsertTest).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 200 with processed:0 and empty failed for an empty batch', async () => {
+    const res = await POST(makeRequest({ files: [] }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ processed: 0, failed: [] });
+  });
+
+  // --- partial failures ---
+  it('returns partial success when one file fails to parse', async () => {
+    mockParseLog
+      .mockReturnValueOnce(PARSED_RESULT)                               // a.log OK
+      .mockImplementationOnce(() => { throw new Error('bad format'); }); // b.log fails
+
+    const res = await POST(makeRequest(BATCH));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ ok: true, board_id: '465136J+2609F808HH', result: 'PASS' });
+    expect(body.processed).toBe(1);
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0]).toMatchObject({ filename: 'b.log', error: expect.stringContaining('bad format') });
   });
 
-  it('calls parseLog with filename and content', async () => {
-    await POST(makeRequest({ filename: 'test.log', content: 'raw content' }));
-    expect(mockParseLog).toHaveBeenCalledWith('test.log', 'raw content');
-  });
+  it('returns partial success when one file fails at DB upsert', async () => {
+    mockUpsertTest
+      .mockResolvedValueOnce(undefined)                          // a.log OK
+      .mockRejectedValueOnce(new Error('DB connection failed')); // b.log fails
 
-  it('calls upsertTest with parsed result', async () => {
-    await POST(makeRequest({ filename: 'test.log', content: 'raw' }));
-    expect(mockUpsertTest).toHaveBeenCalledWith(PARSED_RESULT);
-  });
-
-  it('returns 500 when parseLog throws', async () => {
-    mockParseLog.mockImplementation(() => { throw new Error('bad format'); });
-    const res = await POST(makeRequest({ filename: 'bad.log', content: 'garbage' }));
-    expect(res.status).toBe(500);
+    const res = await POST(makeRequest(BATCH));
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toMatch(/bad format/);
+    expect(body.processed).toBe(1);
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0]).toMatchObject({ filename: 'b.log', error: 'DB connection failed' });
   });
 
-  it('returns 500 when upsertTest rejects', async () => {
-    mockUpsertTest.mockRejectedValue(new Error('DB connection failed'));
-    const res = await POST(makeRequest({ filename: 'test.log', content: 'data' }));
-    expect(res.status).toBe(500);
+  it('returns processed:0 with all files in failed when every file errors', async () => {
+    mockParseLog.mockImplementation(() => { throw new Error('parse fail'); });
+
+    const res = await POST(makeRequest(BATCH));
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toMatch(/DB connection failed/);
+    expect(body.processed).toBe(0);
+    expect(body.failed).toHaveLength(2);
+    expect(body.failed.map((f: { filename: string }) => f.filename)).toEqual(['a.log', 'b.log']);
   });
 });

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /api/ingest
+ *
+ * Receives a raw ICT log file from the Windows ingest script,
+ * parses it, and upserts it into Supabase.
+ *
+ * Request headers:
+ *   x-ingest-secret: <INGEST_SECRET env var>
+ *
+ * Request body (JSON):
+ *   { filename: string, content: string }
+ *
+ * Responses:
+ *   200  { ok: true, board_id: string, result: "PASS" | "FAIL" }
+ *   400  { error: string }   — missing/invalid body
+ *   401  { error: string }   — bad or missing secret
+ *   500  { error: string }   — parse or DB failure
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { parseLog } from '@/lib/ict-parser';
+import { upsertTest } from '@/lib/ict-db';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // --- auth ---
+  const secret = process.env.INGEST_SECRET;
+  if (!secret || req.headers.get('x-ingest-secret') !== secret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // --- parse body ---
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).filename !== 'string' ||
+    typeof (body as Record<string, unknown>).content !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'Body must be { filename: string, content: string }' },
+      { status: 400 }
+    );
+  }
+
+  const { filename, content } = body as { filename: string; content: string };
+
+  // --- parse log ---
+  let parsed;
+  try {
+    parsed = parseLog(filename, content);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `Parse error: ${msg}` }, { status: 500 });
+  }
+
+  // --- upsert to Supabase ---
+  try {
+    await upsertTest(parsed);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB error: ${msg}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, board_id: parsed.board_id, result: parsed.result });
+}

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,25 +1,29 @@
 /**
  * POST /api/ingest
  *
- * Receives a raw ICT log file from the Windows ingest script,
- * parses it, and upserts it into Supabase.
+ * Receives a batch of raw ICT log files from the Windows ingest script,
+ * parses them, and upserts into Supabase.
  *
  * Request headers:
  *   x-ingest-secret: <INGEST_SECRET env var>
  *
  * Request body (JSON):
- *   { filename: string, content: string }
+ *   { files: Array<{ filename: string, content: string }> }
  *
  * Responses:
- *   200  { ok: true, board_id: string, result: "PASS" | "FAIL" }
+ *   200  { processed: number, failed: Array<{ filename: string, error: string }> }
  *   400  { error: string }   — missing/invalid body
  *   401  { error: string }   — bad or missing secret
- *   500  { error: string }   — parse or DB failure
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { parseLog } from '@/lib/ict-parser';
 import { upsertTest } from '@/lib/ict-db';
+
+interface IngestFile {
+  filename: string;
+  content: string;
+}
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   // --- auth ---
@@ -39,33 +43,45 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (
     typeof body !== 'object' ||
     body === null ||
-    typeof (body as Record<string, unknown>).filename !== 'string' ||
-    typeof (body as Record<string, unknown>).content !== 'string'
+    !Array.isArray((body as Record<string, unknown>).files)
   ) {
     return NextResponse.json(
-      { error: 'Body must be { filename: string, content: string }' },
+      { error: 'Body must be { files: Array<{ filename: string, content: string }> }' },
       { status: 400 }
     );
   }
 
-  const { filename, content } = body as { filename: string; content: string };
+  const { files } = body as { files: unknown[] };
 
-  // --- parse log ---
-  let parsed;
-  try {
-    parsed = parseLog(filename, content);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: `Parse error: ${msg}` }, { status: 500 });
+  for (const file of files) {
+    if (
+      typeof file !== 'object' ||
+      file === null ||
+      typeof (file as Record<string, unknown>).filename !== 'string' ||
+      typeof (file as Record<string, unknown>).content !== 'string'
+    ) {
+      return NextResponse.json(
+        { error: 'Each file entry must be { filename: string, content: string }' },
+        { status: 400 }
+      );
+    }
   }
 
-  // --- upsert to Supabase ---
-  try {
-    await upsertTest(parsed);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: `DB error: ${msg}` }, { status: 500 });
+  const validFiles = files as IngestFile[];
+
+  // --- process each file; accumulate results ---
+  const failed: Array<{ filename: string; error: string }> = [];
+  let processed = 0;
+
+  for (const { filename, content } of validFiles) {
+    try {
+      const parsed = parseLog(filename, content);
+      await upsertTest(parsed);
+      processed++;
+    } catch (err) {
+      failed.push({ filename, error: err instanceof Error ? err.message : String(err) });
+    }
   }
 
-  return NextResponse.json({ ok: true, board_id: parsed.board_id, result: parsed.result });
+  return NextResponse.json({ processed, failed });
 }

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -3,7 +3,7 @@
  *
  * Requires env vars:
  *   SUPABASE_URL
- *   SUPABASE_SERVICE_ROLE_KEY   (service role, not anon key)
+ *   SUPABASE_SERVICE_KEY   (service role, not anon key)
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -16,8 +16,8 @@ let _client: ReturnType<typeof createClient> | null = null;
 function getClient() {
   if (_client) return _client;
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  const key = process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY must be set');
   _client = createClient(url, key);
   return _client;
 }

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -9,11 +9,17 @@
 import { createClient } from '@supabase/supabase-js';
 import type { ParsedTest } from './ict-parser';
 
+// Module-level singleton — one client per Vercel function instance,
+// reused across all upsertTest() calls in the same request batch.
+let _client: ReturnType<typeof createClient> | null = null;
+
 function getClient() {
+  if (_client) return _client;
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
-  return createClient(url, key);
+  _client = createClient(url, key);
+  return _client;
 }
 
 /**

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -1,0 +1,105 @@
+/**
+ * ict-db.ts — Supabase upsert logic for ICT test data.
+ *
+ * Requires env vars:
+ *   SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY   (service role, not anon key)
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import type { ParsedTest } from './ict-parser';
+
+function getClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  return createClient(url, key);
+}
+
+/**
+ * Upsert a fully-parsed test session into Supabase.
+ *
+ * Order:
+ *   1. products  (upsert)
+ *   2. boards    (upsert)
+ *   3. tests     (upsert with dedup key; capture id)
+ *   4. test_errors (insert only when test row was newly created)
+ */
+export async function upsertTest(parsed: ParsedTest): Promise<void> {
+  const sb = getClient();
+
+  // 1. products
+  const { error: prodErr } = await sb
+    .from('products')
+    .upsert(
+      {
+        id: parsed.product_id,
+        part_number: parsed.part_number,
+        revision: parsed.revision,
+        family: parsed.family,
+      },
+      { onConflict: 'id' }
+    );
+  if (prodErr) throw new Error(`products upsert failed: ${prodErr.message}`);
+
+  // 2. boards
+  const { error: boardErr } = await sb
+    .from('boards')
+    .upsert(
+      {
+        id: parsed.board_id,
+        product_id: parsed.product_id,
+        mac_address: parsed.mac_address,
+      },
+      { onConflict: 'id' }
+    );
+  if (boardErr) throw new Error(`boards upsert failed: ${boardErr.message}`);
+
+  // 3. tests — upsert with ignoreDuplicates so we can detect new vs existing
+  const { data: testData, error: testErr } = await sb
+    .from('tests')
+    .upsert(
+      {
+        board_id: parsed.board_id,
+        start_time: parsed.start_time.toISOString(),
+        end_time: parsed.end_time.toISOString(),
+        result: parsed.result,
+        operator_id: parsed.operator_id,
+        tester: parsed.tester,
+        fixture_id: parsed.fixture_id,
+        testplan: parsed.testplan,
+        platform: parsed.platform,
+      },
+      { onConflict: 'board_id,start_time,end_time', ignoreDuplicates: true }
+    )
+    .select('id')
+    .maybeSingle();
+  if (testErr) throw new Error(`tests upsert failed: ${testErr.message}`);
+
+  // If null the row already existed (ignoreDuplicates); skip errors to avoid duplication
+  if (!testData) return;
+
+  const testId = testData.id as number;
+
+  // 4. test_errors
+  if (parsed.errors.length === 0) return;
+
+  const { error: errErr } = await sb.from('test_errors').insert(
+    parsed.errors.map((e) => ({
+      test_id: testId,
+      component: e.component,
+      component_value: e.component_value,
+      part_number: e.part_number,
+      measured_raw: e.measured_raw,
+      measured: e.measured,
+      nominal_raw: e.nominal_raw,
+      nominal: e.nominal,
+      high_limit_raw: e.high_limit_raw,
+      high_limit: e.high_limit,
+      low_limit_raw: e.low_limit_raw,
+      low_limit: e.low_limit,
+      unit: e.unit,
+    }))
+  );
+  if (errErr) throw new Error(`test_errors insert failed: ${errErr.message}`);
+}

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -6,19 +6,23 @@
  *   SUPABASE_SERVICE_KEY   (service role, not anon key)
  */
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { ParsedTest } from './ict-parser';
+
+// Untyped client — we don't use Supabase's generated schema types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UntypedClient = SupabaseClient<any, any, any>;
 
 // Module-level singleton — one client per Vercel function instance,
 // reused across all upsertTest() calls in the same request batch.
-let _client: ReturnType<typeof createClient> | null = null;
+let _client: UntypedClient | null = null;
 
-function getClient() {
+function getClient(): UntypedClient {
   if (_client) return _client;
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_KEY;
   if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY must be set');
-  _client = createClient(url, key);
+  _client = createClient(url, key) as UntypedClient;
   return _client;
 }
 

--- a/src/lib/ict-parser.ts
+++ b/src/lib/ict-parser.ts
@@ -1,0 +1,247 @@
+/**
+ * ict-parser.ts — pure ICT log parser, no DB dependencies.
+ *
+ * Log format (one file = one test session):
+ *   - One or more test "runs" separated by 40-dash dividers.
+ *     Each run appears TWICE (ICT tester artifact); we deduplicate by component name.
+ *   - A single metadata section at end of file, lines prefixed with &v1S / &v2S / &v3S.
+ */
+
+export interface ParsedTest {
+  board_id: string;       // "465136J+2609F808HH"  (canonical: + not _)
+  product_id: string;     // part before +: "465136J"
+  family: string;
+  part_number: string;    // "8215911"
+  revision: string;       // "13"
+  mac_address: string;
+  result: 'PASS' | 'FAIL';
+  start_time: Date;
+  end_time: Date;
+  operator_id: string;
+  tester: string;
+  fixture_id: string;
+  testplan: string;
+  platform: string;
+  errors: ParsedError[];
+}
+
+export interface ParsedError {
+  component: string;
+  component_value: string;
+  part_number: string;
+  measured_raw: string;
+  measured: number | null;
+  nominal_raw: string;
+  nominal: number | null;
+  high_limit_raw: string;
+  high_limit: number | null;
+  low_limit_raw: string;
+  low_limit: number | null;
+  unit: string;
+}
+
+const SEPARATOR = '----------------------------------------';
+
+/**
+ * Convert a value string with optional SI suffix to its SI base unit.
+ * Suffixes: u → ×10⁻⁶, p → ×10⁻¹², k → ×10³, M → ×10⁶
+ * Returns null when the string cannot be parsed.
+ */
+export function parseSiValue(raw: string): number | null {
+  const match = raw.trim().match(/^([\d.]+)([upkM]?)$/);
+  if (!match) return null;
+  const num = parseFloat(match[1]);
+  const suffix = match[2];
+  const multipliers: Record<string, number> = { u: 1e-6, p: 1e-12, k: 1e3, M: 1e6, '': 1 };
+  return num * (multipliers[suffix] ?? 1);
+}
+
+/**
+ * Parse an YYMMDDHHMMSS timestamp string (e.g. "260311134729") into a Date (UTC).
+ */
+export function parseTimestamp(ts: string): Date {
+  const s = ts.trim();
+  const year = 2000 + parseInt(s.slice(0, 2), 10);
+  const month = parseInt(s.slice(2, 4), 10) - 1; // 0-based
+  const day = parseInt(s.slice(4, 6), 10);
+  const hour = parseInt(s.slice(6, 8), 10);
+  const min = parseInt(s.slice(8, 10), 10);
+  const sec = parseInt(s.slice(10, 12), 10);
+  return new Date(Date.UTC(year, month, day, hour, min, sec));
+}
+
+/**
+ * Parse a raw ICT log file.
+ *
+ * @param filename  Original filename, e.g. "465136J_2609F808HH.log".
+ *                  The first underscore is replaced with + to form board_id.
+ * @param content   Full file text (LF or CRLF).
+ */
+export function parseLog(filename: string, content: string): ParsedTest {
+  const lines = content.split(/\r?\n/);
+
+  // --- board_id from filename ---
+  const base = filename.replace(/\.log$/i, '');
+  const firstUnderscore = base.indexOf('_');
+  const board_id =
+    firstUnderscore !== -1
+      ? base.slice(0, firstUnderscore) + '+' + base.slice(firstUnderscore + 1)
+      : base;
+  const product_id = board_id.split('+')[0] ?? board_id;
+
+  // --- collect metadata from &v[123]S lines ---
+  const meta: Record<string, string> = {};
+  let result: 'PASS' | 'FAIL' | null = null;
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    // Metadata lines are PCL escape sequences: ESC (0x1b) + &v2S + space + content
+    const metaMatch = line.match(/^\x1b&v[123]S\s*(.*)/);
+    if (!metaMatch) continue;
+
+    const value = metaMatch[1].trim();
+
+    if (value.includes('BOARD ICT PASS')) { result = 'PASS'; continue; }
+    if (value.includes('BOARD ICT FAIL')) { result = 'FAIL'; continue; }
+    if (value.startsWith('Testplan-')) { meta['testplan'] = value.slice('Testplan-'.length); continue; }
+    if (value.startsWith('***') || value.startsWith('###')) continue; // decorative
+
+    const colonIdx = value.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = value.slice(0, colonIdx).trim().toLowerCase();
+    const val = value.slice(colonIdx + 1).trim();
+    meta[key] = val;
+  }
+
+  // P/N line is "8215911 Rev:13"
+  let part_number = '';
+  let revision = '';
+  const pn = meta['p/n'] ?? '';
+  const revMatch = pn.match(/^(.+?)\s+Rev:(.+)$/);
+  if (revMatch) {
+    part_number = revMatch[1].trim();
+    revision = revMatch[2].trim();
+  } else {
+    part_number = pn;
+  }
+
+  const start_time = meta['st'] ? parseTimestamp(meta['st']) : new Date(0);
+  const end_time = meta['et'] ? parseTimestamp(meta['et']) : new Date(0);
+
+  // --- collect error blocks from all runs, dedup by component name ---
+  const errorMap = new Map<string, ParsedError>();
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i].trimEnd();
+
+    if (line !== SEPARATOR) { i++; continue; }
+
+    // We're at a separator — peek ahead to see if this starts an error block
+    // A separator followed by a "X HAS FAILED" line (after skipping blank/machine/date lines)
+    let j = i + 1;
+
+    // Skip equipment identifier (C2-ROTFIRM4.1) and date line
+    while (j < lines.length && lines[j].trimEnd() !== SEPARATOR && !lines[j].includes('HAS FAILED')) {
+      j++;
+    }
+
+    if (j >= lines.length || lines[j].trimEnd() === SEPARATOR) { i++; continue; }
+
+    // Parse consecutive error blocks until next run header or end
+    while (j < lines.length) {
+      const l = lines[j].trimEnd();
+
+      if (l === SEPARATOR) {
+        // Could be: end of error block, start of next error, or end of run
+        // Peek at next non-empty line
+        let k = j + 1;
+        while (k < lines.length && lines[k].trim() === '') k++;
+        if (k >= lines.length) break;
+        const next = lines[k].trimEnd();
+        // If next line starts a new error: continue parsing
+        if (next.includes('HAS FAILED') || next === 'DEVICES IN PARALLEL') {
+          j = k;
+          continue;
+        }
+        // Otherwise end of this run block
+        break;
+      }
+
+      if (l === 'DEVICES IN PARALLEL') { j++; continue; }
+
+      const failedMatch = l.match(/^(\S+)\s+HAS FAILED\s*$/i);
+      if (!failedMatch) { j++; continue; }
+
+      const component = failedMatch[1].toLowerCase();
+      j++;
+
+      // Next line: COMPONENT=value Part# part#
+      const defLine = (lines[j] ?? '').trimEnd();
+      const defMatch = defLine.match(/^[^=]+=([^\s]+)\s+Part#\s+(.+)$/i);
+      const component_value = defMatch ? defMatch[1] : '';
+      const part_number_err = defMatch ? defMatch[2].trim() : '';
+      j++;
+
+      const measLine = (lines[j] ?? '').trimEnd();
+      const measured_raw = measLine.replace(/^Measured:\s*/i, '').trim();
+      j++;
+
+      const nomLine = (lines[j] ?? '').trimEnd();
+      const nominal_raw = nomLine.replace(/^Nominal:\s*/i, '').trim();
+      j++;
+
+      const hiLine = (lines[j] ?? '').trimEnd();
+      const high_limit_raw = hiLine.replace(/^High Limit:\s*/i, '').trim();
+      j++;
+
+      const loLine = (lines[j] ?? '').trimEnd();
+      const low_limit_raw = loLine.replace(/^Low Limit:\s*/i, '').trim();
+      j++;
+
+      const unitLine = (lines[j] ?? '').trimEnd();
+      // e.g. "Capacitance in FARADS" or "Resistance in OHMS"
+      const unitMatch = unitLine.match(/\bin\s+(FARADS|OHMS)\b/i);
+      const unit = unitMatch ? unitMatch[1].toUpperCase() : unitLine.trim();
+      j++;
+
+      // Deduplicate by component name (keep first occurrence)
+      if (!errorMap.has(component)) {
+        errorMap.set(component, {
+          component,
+          component_value,
+          part_number: part_number_err,
+          measured_raw,
+          measured: parseSiValue(measured_raw),
+          nominal_raw,
+          nominal: parseSiValue(nominal_raw),
+          high_limit_raw,
+          high_limit: parseSiValue(high_limit_raw),
+          low_limit_raw,
+          low_limit: parseSiValue(low_limit_raw),
+          unit,
+        });
+      }
+    }
+
+    i = j;
+  }
+
+  return {
+    board_id,
+    product_id,
+    family: meta['family'] ?? '',
+    part_number,
+    revision,
+    mac_address: meta['mac'] ?? '',
+    result: result ?? 'FAIL',
+    start_time,
+    end_time,
+    operator_id: meta['operator id'] ?? '',
+    tester: meta['tester'] ?? '',
+    fixture_id: meta['fixture_id'] ?? '',
+    testplan: meta['testplan'] ?? '',
+    platform: meta['pf'] ?? '',
+    errors: Array.from(errorMap.values()),
+  };
+}

--- a/src/pipeline/CLAUDE.md
+++ b/src/pipeline/CLAUDE.md
@@ -46,7 +46,7 @@ Supabase (free tier, 500MB limit)
 
 ```
 SUPABASE_URL=
-SUPABASE_SERVICE_ROLE_KEY=    # service role, not anon key
+SUPABASE_SERVICE_KEY=    # service role, not anon key
 INGEST_SECRET=                # arbitrary shared secret, matched in ict-ingest.config.json
 ```
 

--- a/src/pipeline/docs/schema.sql
+++ b/src/pipeline/docs/schema.sql
@@ -1,256 +1,71 @@
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:11 2026
-----------------------------------------
-c103_p HAS FAILED
-C103_P=2.2UF Part# 7088787
-Measured:   2.1509u
-Nominal:    1.6000u
-High Limit: 2.0800u
-Low Limit:  1.2800u
-Capacitance in FARADS
-----------------------------------------
-c407_c HAS FAILED
-C407_C=560PF Part# 7054375
-Measured:   233.26p
-Nominal:    560.00p
-High Limit: 700.00p
-Low Limit:  308.00p
-Capacitance in FARADS
-----------------------------------------
-r7108_2_c HAS FAILED
-R7108_2_C=22.1 Part# 7335548
-Measured:   33.353
-Nominal:    22.100
-High Limit: 25.415
-Low Limit:  21.287
-Resistance in OHMS
-----------------------------------------
-r503 HAS FAILED
-R503=10 Part# 7335581
-Measured:   11.138
-Nominal:    10.000
-High Limit: 10.646
-Low Limit:  9.5240
-Resistance in OHMS
-----------------------------------------
-r210_2_c HAS FAILED
-R210_2_C=49.9 Part# 7334931
-Measured:   21.441
-Nominal:    16.900
-High Limit: 20.280
-Low Limit:  15.210
-Resistance in OHMS
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5612M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-r7308_2_c HAS FAILED
-R7308_2_C=22.1 Part# 7335548
-Measured:   31.217
-Nominal:    22.100
-High Limit: 24.310
-Low Limit:  21.287
-Resistance in OHMS
-----------------------------------------
-r421_2_c HAS FAILED
-R421_2_C=33.2 Part# 7339584
-Measured:   36.499
-Nominal:    33.200
-High Limit: 34.518
-Low Limit:  32.051
-Resistance in OHMS
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:11 2026
-----------------------------------------
-c103_p HAS FAILED
-C103_P=2.2UF Part# 7088787
-Measured:   2.1509u
-Nominal:    1.6000u
-High Limit: 2.0800u
-Low Limit:  1.2800u
-Capacitance in FARADS
-----------------------------------------
-c407_c HAS FAILED
-C407_C=560PF Part# 7054375
-Measured:   233.26p
-Nominal:    560.00p
-High Limit: 700.00p
-Low Limit:  308.00p
-Capacitance in FARADS
-----------------------------------------
-r7108_2_c HAS FAILED
-R7108_2_C=22.1 Part# 7335548
-Measured:   33.353
-Nominal:    22.100
-High Limit: 25.415
-Low Limit:  21.287
-Resistance in OHMS
-----------------------------------------
-r503 HAS FAILED
-R503=10 Part# 7335581
-Measured:   11.138
-Nominal:    10.000
-High Limit: 10.646
-Low Limit:  9.5240
-Resistance in OHMS
-----------------------------------------
-r210_2_c HAS FAILED
-R210_2_C=49.9 Part# 7334931
-Measured:   21.441
-Nominal:    16.900
-High Limit: 20.280
-Low Limit:  15.210
-Resistance in OHMS
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5612M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-r7308_2_c HAS FAILED
-R7308_2_C=22.1 Part# 7335548
-Measured:   31.217
-Nominal:    22.100
-High Limit: 24.310
-Low Limit:  21.287
-Resistance in OHMS
-----------------------------------------
-r421_2_c HAS FAILED
-R421_2_C=33.2 Part# 7339584
-Measured:   36.499
-Nominal:    33.200
-High Limit: 34.518
-Low Limit:  32.051
-Resistance in OHMS
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:23 2026
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5674M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:23 2026
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5674M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:27 2026
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5547M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:27 2026
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5547M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-Board #: 0 
-Version:
-S/N:465136J+2611F8019P
-----------------------------------------
-C2-ROTFIRM4.1
-Thu Mar 12 13:12:30 2026
-----------------------------------------
-r625 HAS FAILED
-R625=20K Part# 7336425
-Measured:   1.5545M
-Nominal:    20.000k
-High Limit: 20.806k
-Low Limit:  19.046k
-Resistance in OHMS
-----------------------------------------
-DEVICES IN PARALLEL
-c640 220p
-----------------------------------------
-Serial #: 465136J+2611F8019P
-&v1S Family: C2-ROT41
-&v1S Serial #:465136J+2611F8019P
-&v1S ############################
-&v1S ##### BOARD ICT FAIL #####
-&v1S ############################
-&v1S Testplan-Released-04-04-2025
-&v1S ST:260312131138
-&v1S ET:260312131230
-&v1S SN:465136J+2611F8019P
-&v1S P/N:8215911 Rev:13
-&v3S Mac:A8698C61316E
-&v1S Mac_FruID:
-&v1S u201_1_c CRC Blank:not test
-&v3S OPERATOR ID:102393
-&v1S PF:Agilent3070 Rev:8.30
-&v3S Fixture_ID: FxSJ_WW4894
-&v1S TESTER:TEST-HP
-&v1S ****************************
+-- ICT Data Viewer — Supabase DDL
+-- Run this in the Supabase SQL editor (Database → SQL Editor).
+-- Requires pg_cron for the rolling-delete schedule:
+--   Database → Extensions → enable pg_cron
 
-*
+-- ------------------------------------------------------------
+-- products: one row per board family / part number
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS products (
+  id           text PRIMARY KEY,  -- e.g. "465136J"
+  part_number  text,              -- "8215911"
+  revision     text,              -- "13"
+  family       text               -- "C2-ROT41"
+);
+
+-- ------------------------------------------------------------
+-- boards: one row per unique serial number
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS boards (
+  id          text PRIMARY KEY,   -- "465136J+2609F808HH"  (canonical: + not _)
+  product_id  text REFERENCES products(id),
+  mac_address text
+);
+
+-- ------------------------------------------------------------
+-- tests: one row per test session (= one log file)
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tests (
+  id           bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  board_id     text        NOT NULL REFERENCES boards(id),
+  start_time   timestamptz NOT NULL,
+  end_time     timestamptz NOT NULL,
+  result       text        NOT NULL,  -- 'PASS' or 'FAIL'
+  operator_id  text,                  -- text: can be "102059" or "JT1227"
+  tester       text,
+  fixture_id   text,
+  testplan     text,
+  platform     text,
+  ingested_at  timestamptz DEFAULT now(),
+  UNIQUE (board_id, start_time, end_time)  -- safe dedup key for re-ingestion
+);
+
+-- ------------------------------------------------------------
+-- test_errors: one row per unique failing component per test
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS test_errors (
+  id               bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  test_id          bigint NOT NULL REFERENCES tests(id) ON DELETE CASCADE,
+  component        text   NOT NULL,  -- "c314_1_c"
+  component_value  text,             -- "1UF"
+  part_number      text,             -- "110-5581-01"
+  measured_raw     text,             -- "0.78327u"
+  measured         float8,           -- SI base unit: Farads or Ohms
+  nominal_raw      text,
+  nominal          float8,
+  high_limit_raw   text,
+  high_limit       float8,
+  low_limit_raw    text,
+  low_limit        float8,
+  unit             text              -- "FARADS" or "OHMS"
+);
+
+-- ------------------------------------------------------------
+-- rolling 3-month delete  (pg_cron)
+-- Runs daily at 02:00 UTC; test_errors cascade automatically.
+-- ------------------------------------------------------------
+SELECT cron.schedule(
+  'delete-old-tests',
+  '0 2 * * *',
+  $$DELETE FROM tests WHERE end_time < now() - INTERVAL '3 months'$$
+);

--- a/src/pipeline/ict-ingest.config.json.template
+++ b/src/pipeline/ict-ingest.config.json.template
@@ -1,5 +1,6 @@
 {
   "directories": ["C:\\ICT\\logs\\line1", "C:\\ICT\\logs\\line2"],
   "apiUrl": "https://your-app.vercel.app/api/ingest",
-  "apiSecret": "your-shared-secret"
+  "apiSecret": "your-shared-secret",
+  "batchSize": 20
 }

--- a/src/pipeline/ict-ingest.ps1
+++ b/src/pipeline/ict-ingest.ps1
@@ -1,3 +1,7 @@
+param(
+  [switch]$Backfill
+)
+
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $config    = Get-Content "$scriptDir\ict-ingest.config.json" | ConvertFrom-Json
 $logFile   = "$scriptDir\ingested.txt"
@@ -7,6 +11,10 @@ if (Test-Path $logFile) {
   Get-Content $logFile | ForEach-Object { $ingested[$_] = $true }
 }
 
+$batchSize = if ($Backfill) { 50 } else { 20 }
+
+# Collect all candidate files across configured directories
+$candidates = [System.Collections.ArrayList]@()
 foreach ($dir in $config.directories) {
   if (-not (Test-Path $dir)) {
     Write-Host "Directory not found, skipping: $dir"
@@ -14,29 +22,64 @@ foreach ($dir in $config.directories) {
   }
 
   Get-ChildItem -Path $dir -File | ForEach-Object {
-    $filename = $_.Name
-    if ($ingested.ContainsKey($filename)) { return }
+    if (-not $Backfill -and $ingested.ContainsKey($_.Name)) { return }
+    $null = $candidates.Add($_)
+  }
+}
 
-    try {
-      $content = Get-Content $_.FullName -Raw -Encoding UTF8
+Write-Host "Files to process: $($candidates.Count)$(if ($Backfill) { ' (backfill)' })"
 
-      $body = @{
-        filename = $filename
-        content  = $content
-      } | ConvertTo-Json -Depth 2
+# Send in batches
+$batchNum = 0
+for ($i = 0; $i -lt $candidates.Count; $i += $batchSize) {
+  $end   = [Math]::Min($i + $batchSize - 1, $candidates.Count - 1)
+  $batch = $candidates[$i..$end]
+  $batchNum++
 
-      $response = Invoke-RestMethod `
-        -Uri $config.apiUrl `
-        -Method POST `
-        -ContentType "application/json" `
-        -Headers @{ "x-ingest-secret" = $config.apiSecret } `
-        -Body $body
-
-      Add-Content -Path $logFile -Value $filename
-      Write-Host "OK: $filename"
-
-    } catch {
-      Write-Host "FAILED: $filename - $($_.Exception.Message)"
+  # Read file contents and build request payload
+  $files = @()
+  foreach ($f in $batch) {
+    $files += @{
+      filename = $f.Name
+      content  = Get-Content $f.FullName -Raw -Encoding UTF8
     }
+  }
+
+  try {
+    $body = @{ files = $files } | ConvertTo-Json -Depth 3 -Compress
+
+    $response = Invoke-RestMethod `
+      -Uri $config.apiUrl `
+      -Method POST `
+      -ContentType "application/json" `
+      -Headers @{ "x-ingest-secret" = $config.apiSecret } `
+      -Body $body
+
+    # Build set of failed filenames from server response
+    $failedNames = @{}
+    foreach ($entry in $response.failed) {
+      $failedNames[$entry.filename] = $entry.error
+    }
+
+    # Log results and append successes to ingested.txt
+    foreach ($f in $batch) {
+      if ($failedNames.ContainsKey($f.Name)) {
+        Write-Host "FAILED: $($f.Name) - $($failedNames[$f.Name])"
+      } else {
+        Add-Content -Path $logFile -Value $f.Name
+        Write-Host "OK: $($f.Name)"
+      }
+    }
+
+    Write-Host "Batch $batchNum`: processed=$($response.processed), failed=$($response.failed.Count)"
+
+  } catch {
+    Write-Host "BATCH $batchNum ERROR: $($_.Exception.Message)"
+    # No files appended; entire batch will be retried on next run
+  }
+
+  # Pause between batches (skip after the last one)
+  if ($i + $batchSize -lt $candidates.Count) {
+    Start-Sleep -Milliseconds 200
   }
 }

--- a/src/pipeline/ict-ingest.ps1
+++ b/src/pipeline/ict-ingest.ps1
@@ -29,7 +29,7 @@ Write-Host "Files to process: $($candidates.Count)"
 $batchNum = 0
 for ($i = 0; $i -lt $candidates.Count; $i += $batchSize) {
   $end   = [Math]::Min($i + $batchSize - 1, $candidates.Count - 1)
-  $batch = $candidates[$i..$end]
+  $batch = @($candidates)[$i..$end]
   $batchNum++
 
   $files = @()

--- a/src/pipeline/ict-ingest.ps1
+++ b/src/pipeline/ict-ingest.ps1
@@ -1,7 +1,3 @@
-param(
-  [switch]$Backfill
-)
-
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $config    = Get-Content "$scriptDir\ict-ingest.config.json" | ConvertFrom-Json
 $logFile   = "$scriptDir\ingested.txt"
@@ -11,7 +7,7 @@ if (Test-Path $logFile) {
   Get-Content $logFile | ForEach-Object { $ingested[$_] = $true }
 }
 
-$batchSize = if ($Backfill) { 50 } else { 20 }
+$batchSize = if ($config.PSObject.Properties['batchSize']) { [int]$config.batchSize } else { 20 }
 
 # Collect all candidate files across configured directories
 $candidates = [System.Collections.ArrayList]@()
@@ -22,12 +18,12 @@ foreach ($dir in $config.directories) {
   }
 
   Get-ChildItem -Path $dir -File | ForEach-Object {
-    if (-not $Backfill -and $ingested.ContainsKey($_.Name)) { return }
+    if ($ingested.ContainsKey($_.Name)) { return }
     $null = $candidates.Add($_)
   }
 }
 
-Write-Host "Files to process: $($candidates.Count)$(if ($Backfill) { ' (backfill)' })"
+Write-Host "Files to process: $($candidates.Count)"
 
 # Send in batches
 $batchNum = 0
@@ -36,7 +32,6 @@ for ($i = 0; $i -lt $candidates.Count; $i += $batchSize) {
   $batch = $candidates[$i..$end]
   $batchNum++
 
-  # Read file contents and build request payload
   $files = @()
   foreach ($f in $batch) {
     $files += @{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,12 +26,19 @@
       "@/*": [
         "./src/*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
This PR implements a complete data ingestion pipeline for ICT (In-Circuit Test) log files. It includes a parser to extract test results and component failures from raw log files, a Supabase database layer to persist the data, and a Next.js API endpoint to receive batched uploads from a Windows PowerShell script.

## Key Changes

### Database Schema (`src/pipeline/docs/schema.sql`)
- Replaced sample test data with production DDL for Supabase
- Created four tables: `products`, `boards`, `tests`, and `test_errors`
- Added automatic 3-month rolling delete via `pg_cron` extension
- Implemented deduplication key on tests: `(board_id, start_time, end_time)`

### ICT Log Parser (`src/lib/ict-parser.ts`)
- Implemented `parseLog()` to extract test metadata and component failures from raw ICT logs
- Added `parseSiValue()` to convert SI-suffixed values (µ, p, k, M) to base units
- Added `parseTimestamp()` to parse YYMMDDHHMMSS format to UTC Date
- Handles deduplication of errors across multiple test runs (ICT tester artifact)
- Extracts board ID, product ID, family, part number, revision, MAC address, operator ID, tester, fixture ID, testplan, and platform

### Supabase Integration (`src/lib/ict-db.ts`)
- Implemented `upsertTest()` to persist parsed test data in correct order:
  1. Upsert product record
  2. Upsert board record
  3. Upsert test record with deduplication
  4. Insert test_errors only for newly created tests (avoids duplication on re-ingestion)
- Uses service role key for full write access

### API Endpoint (`src/app/api/ingest/route.ts`)
- Created `POST /api/ingest` to receive batched file uploads
- Validates `x-ingest-secret` header for authentication
- Accepts JSON body with array of `{ filename, content }` objects
- Returns partial success response: `{ processed: number, failed: Array<{ filename, error }> }`
- Gracefully handles per-file parse and DB errors without failing the entire batch

### PowerShell Ingest Script (`src/pipeline/ict-ingest.ps1`)
- Refactored to send files in configurable batches (default 20 per request)
- Changed from single-file to multi-file request format
- Improved error handling to track per-file failures from server response
- Maintains ingested.txt log of successfully processed files

### Test Coverage
- Added comprehensive test suite (`src/__tests__/ict-parser.test.ts`) covering:
  - SI value parsing (µ, p, k, M suffixes)
  - Timestamp parsing
  - Metadata extraction (family, part number, revision, operator ID, etc.)
  - Error deduplication across multiple test runs
  - All 4 sample log files (PASS and FAIL results)
- Added Supabase integration tests (`src/__tests__/ict-db.test.ts`) with fully mocked DB calls
- Added API endpoint tests (`src/__tests__/ingest-route.test.ts`) covering auth, validation, and partial failures

### Configuration
- Added `.env.example` with required environment variables
- Updated `ict-ingest.config.json.template` to include `batchSize` parameter
- Added `@supabase/supabase-js` dependency

## Notable Implementation Details
- **Deduplication strategy**: Errors are deduplicated by component name within a single log file (handles ICT tester's duplicate run artifact). Tests are deduplicated at the database level using `(board_id, start_time, end_time)` as the unique key.
- **Partial batch success**: The ingest endpoint processes all files in a batch and returns which ones succeeded/failed, allowing the PowerShell script to retry only failed files.
- **Board ID normalization**: Filename format `465136J_2609F808HH.log` is converted to canonical board ID `465136J+2

https://claude.ai/code/session_01BvS1R2av9c2Qgb5rMLebE4