### PR TITLE
Add file age filtering and recursive directory scanning to ingest pipeline

### DIFF
--- a/src/pipeline/ict-ingest.config.json.template
+++ b/src/pipeline/ict-ingest.config.json.template
@@ -2,5 +2,6 @@
   "directories": ["C:\\ICT\\logs\\line1", "C:\\ICT\\logs\\line2"],
   "apiUrl": "https://your-app.vercel.app/api/ingest",
   "apiSecret": "your-shared-secret",
-  "batchSize": 20
+  "batchSize": 20,
+  "fileAgeMinutes": 60
 }

--- a/src/pipeline/ict-ingest.ps1
+++ b/src/pipeline/ict-ingest.ps1
@@ -9,6 +9,13 @@ if (Test-Path $logFile) {
 
 $batchSize = if ($config.PSObject.Properties['batchSize']) { [int]$config.batchSize } else { 20 }
 
+$fileAgeMinutes = if ($config.PSObject.Properties['fileAgeMinutes'] -and $null -ne $config.fileAgeMinutes) {
+  [int]$config.fileAgeMinutes
+} else {
+  $null
+}
+$cutoff = if ($null -ne $fileAgeMinutes) { (Get-Date).AddMinutes(-$fileAgeMinutes) } else { $null }
+
 # Collect all candidate files across configured directories
 $candidates = [System.Collections.ArrayList]@()
 foreach ($dir in $config.directories) {
@@ -17,8 +24,9 @@ foreach ($dir in $config.directories) {
     continue
   }
 
-  Get-ChildItem -Path $dir -File | ForEach-Object {
+  Get-ChildItem -Path $dir -File -Recurse | ForEach-Object {
     if ($ingested.ContainsKey($_.Name)) { return }
+    if ($null -ne $cutoff -and $_.LastWriteTime -lt $cutoff) { return }
     $null = $candidates.Add($_)
   }
 }


### PR DESCRIPTION
## Summary
Enhanced the ICT ingest pipeline to support filtering files by age and recursively scanning subdirectories, providing more granular control over which files are processed.

## Key Changes
- **File age filtering**: Added `fileAgeMinutes` configuration parameter to exclude files older than a specified threshold. Files are compared against a cutoff timestamp calculated from the current time.
- **Recursive directory scanning**: Modified `Get-ChildItem` to use the `-Recurse` flag, enabling the pipeline to process files in subdirectories of configured directories.
- **Configuration template**: Updated the template configuration file to include the new `fileAgeMinutes` parameter with a default value of 60 minutes.

## Implementation Details
- The `fileAgeMinutes` parameter is optional and defaults to `$null` if not specified, maintaining backward compatibility.
- When `fileAgeMinutes` is configured, files with `LastWriteTime` earlier than the calculated cutoff are skipped during collection.
- The age check is performed early in the filtering pipeline (after checking ingestion status) to minimize unnecessary processing.

https://claude.ai/code/session_01UXc11r1f5DuSQMcwYVmPT6