### PR TITLE
Use database-generated product IDs instead of part numbers

### DIFF
--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -67,8 +67,11 @@ beforeEach(() => {
   process.env.SUPABASE_SERVICE_KEY = 'test-key';
 
   // Default happy path:
-  // products upsert
-  const productsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+  // products upsert — chain: .upsert().select().single()
+  const productsSingleFn = jest.fn().mockResolvedValue({ data: { id: 'prod-uuid-001' }, error: null });
+  const productsSelectFn = jest.fn().mockReturnValue({ single: productsSingleFn });
+  const productsUpsertFn = jest.fn().mockReturnValue({ select: productsSelectFn });
+  const productsChain = { upsert: productsUpsertFn };
   // boards upsert
   const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
   // tests upsert — chain: .upsert().select().maybeSingle()
@@ -104,7 +107,7 @@ describe('upsertTest', () => {
     const upsertArg = mockFrom.mock.results[1].value.upsert.mock.calls[0][0];
     expect(upsertArg).toMatchObject({
       serial_number: 'SN-XXXX-000001',
-      product_id:    'PART-REDACTED-001',
+      product_id:    'prod-uuid-001',
       mac_address:   '020000000001',
       rev:           '13',
     });
@@ -138,7 +141,10 @@ describe('upsertTest', () => {
 
   it('skips test_errors insert when test already existed (ignoreDuplicates → null)', async () => {
     // Re-wire: tests returns null (already existed)
-    const productsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+    const productsSingleFn = jest.fn().mockResolvedValue({ data: { id: 'prod-uuid-001' }, error: null });
+    const productsSelectFn = jest.fn().mockReturnValue({ single: productsSingleFn });
+    const productsUpsertFn = jest.fn().mockReturnValue({ select: productsSelectFn });
+    const productsChain = { upsert: productsUpsertFn };
     const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
     const maybeSingleFn = jest.fn().mockResolvedValue({ data: null, error: null });
     const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
@@ -158,9 +164,10 @@ describe('upsertTest', () => {
 
   it('throws when products upsert fails', async () => {
     mockFrom.mockReset();
-    mockFrom.mockReturnValueOnce({
-      upsert: jest.fn().mockResolvedValue({ error: { message: 'DB down' } }),
-    });
+    const singleFn = jest.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } });
+    const selectFn = jest.fn().mockReturnValue({ single: singleFn });
+    const upsertFn = jest.fn().mockReturnValue({ select: selectFn });
+    mockFrom.mockReturnValueOnce({ upsert: upsertFn });
     await expect(upsertTest(PARSED)).rejects.toThrow('products upsert failed: DB down');
   });
 

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -38,7 +38,7 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
   const sb = getClient();
 
   // 1. products
-  const { error: prodErr } = await sb
+  const { data: productData, error: prodErr } = await sb
     .from('products')
     .upsert(
       {
@@ -46,8 +46,11 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
         product_name: parsed.product_name,
       },
       { onConflict: 'part_number' }
-    );
+    )
+    .select('id')
+    .single();
   if (prodErr) throw new Error(`products upsert failed: ${prodErr.message}`);
+  const productId = productData!.id as string;
 
   // 2. boards
   const { error: boardErr } = await sb
@@ -55,7 +58,7 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
     .upsert(
       {
         serial_number: parsed.serial_number,
-        product_id:    parsed.product_id,
+        product_id:    productId,
         mac_address:   parsed.mac_address,
         rev:           parsed.rev,
       },


### PR DESCRIPTION
## Summary
Updated the `upsertTest` function to retrieve and use the database-generated `id` from the products table instead of using the `part_number` (parsed product_id) when upserting board records.

## Key Changes
- Modified the products upsert query to chain `.select('id').single()` to retrieve the generated product ID from the database
- Updated the boards upsert to use the retrieved `productId` instead of `parsed.product_id`
- Updated all related test mocks to properly chain the upsert/select/single methods and return the product ID in the response

## Implementation Details
- The products upsert now returns the database-generated `id` field, which is then used as the foreign key reference in the boards table
- This ensures referential integrity by using the actual database ID rather than relying on the part_number as an identifier
- Test cases were updated to reflect the new mock chain structure and verify that the correct product ID (`prod-uuid-001`) is used in board records

https://claude.ai/code/session_01Q4uWisGw5jaTTB1r3vHyNq