### PR TITLE
Fix boards upsert to return board ID for test insertion

### DIFF
--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -72,8 +72,11 @@ beforeEach(() => {
   const productsSelectFn = jest.fn().mockReturnValue({ single: productsSingleFn });
   const productsUpsertFn = jest.fn().mockReturnValue({ select: productsSelectFn });
   const productsChain = { upsert: productsUpsertFn };
-  // boards upsert
-  const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+  // boards upsert — chain: .upsert().select().single()
+  const boardsSingleFn = jest.fn().mockResolvedValue({ data: { id: 'board-uuid-001' }, error: null });
+  const boardsSelectFn = jest.fn().mockReturnValue({ single: boardsSingleFn });
+  const boardsUpsertFn = jest.fn().mockReturnValue({ select: boardsSelectFn });
+  const boardsChain = { upsert: boardsUpsertFn };
   // tests upsert — chain: .upsert().select().maybeSingle()
   const maybeSingleFn = jest.fn().mockResolvedValue({ data: { id: 42 }, error: null });
   const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
@@ -118,7 +121,7 @@ describe('upsertTest', () => {
     expect(mockFrom.mock.calls[2][0]).toBe('tests');
     const upsertArg = mockFrom.mock.results[2].value.upsert.mock.calls[0][0];
     expect(upsertArg).toMatchObject({
-      board_id:    'SN-XXXX-000001',
+      board_id:    'board-uuid-001',
       result:      'PASS',
       operator_id: 'operator-01',
       source_file: 'PROD-001_SN-XXXX-000001.log',
@@ -145,7 +148,10 @@ describe('upsertTest', () => {
     const productsSelectFn = jest.fn().mockReturnValue({ single: productsSingleFn });
     const productsUpsertFn = jest.fn().mockReturnValue({ select: productsSelectFn });
     const productsChain = { upsert: productsUpsertFn };
-    const boardsChain = { upsert: jest.fn().mockResolvedValue({ error: null }) };
+    const boardsSingleFn2 = jest.fn().mockResolvedValue({ data: { id: 'board-uuid-001' }, error: null });
+    const boardsSelectFn2 = jest.fn().mockReturnValue({ single: boardsSingleFn2 });
+    const boardsUpsertFn2 = jest.fn().mockReturnValue({ select: boardsSelectFn2 });
+    const boardsChain = { upsert: boardsUpsertFn2 };
     const maybeSingleFn = jest.fn().mockResolvedValue({ data: null, error: null });
     const selectFn = jest.fn().mockReturnValue({ maybeSingle: maybeSingleFn });
     const testsUpsertFn = jest.fn().mockReturnValue({ select: selectFn });

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -53,7 +53,7 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
   const productId = productData!.id as string;
 
   // 2. boards
-  const { error: boardErr } = await sb
+  const { data: boardData, error: boardErr } = await sb
     .from('boards')
     .upsert(
       {
@@ -63,15 +63,18 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
         rev:           parsed.rev,
       },
       { onConflict: 'serial_number' }
-    );
+    )
+    .select('id')
+    .single();
   if (boardErr) throw new Error(`boards upsert failed: ${boardErr.message}`);
+  const boardId = boardData!.id as string;
 
   // 3. tests — upsert with ignoreDuplicates so we can detect new vs existing
   const { data: testData, error: testErr } = await sb
     .from('tests')
     .upsert(
       {
-        board_id:    parsed.serial_number,
+        board_id:    boardId,
         start_time:  parsed.start_time.toISOString(),
         end_time:    parsed.end_time.toISOString(),
         result:      parsed.result,


### PR DESCRIPTION
## Summary
Updated the boards upsert operation to properly retrieve and return the board ID, which is then used when inserting test records. Previously, the board's serial number was being used as the board_id in tests, but now the actual database-generated board UUID is used.

## Key Changes
- Modified `boards` upsert chain to include `.select('id').single()` to retrieve the inserted/updated board's ID
- Updated the upsert response destructuring to capture `boardData` containing the board ID
- Changed test insertion to use the retrieved `boardId` instead of `parsed.serial_number` for the `board_id` field
- Updated test mocks to reflect the new boards upsert chain structure with proper return values

## Implementation Details
- The boards upsert now follows the same pattern as the products upsert: `.upsert().select().single()`
- The board UUID (`board-uuid-001` in tests) is now properly propagated to test records, establishing the correct foreign key relationship
- Error handling remains in place for the boards upsert operation

https://claude.ai/code/session_01P1TvJRdaqXU2k34118s4Hw