### PR TITLE
Add authentication & guest mode with Supabase Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 # Supabase (required by the viewer + ingest pipeline)
 SUPABASE_URL=https://your-project-ref.supabase.co
-# Use the service role key, NOT the anon key
+# Use the service role key, NOT the anon key — server-side ingest only
 SUPABASE_SERVICE_KEY=your-service-role-key
+
+# Public Supabase config — safe to expose to the browser (used by the auth client)
+# The anon key enforces RLS; the service role key above bypasses it.
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Ingest authentication — arbitrary shared secret; must match apiSecret in ict-ingest.config.json
 INGEST_SECRET=your-ingest-secret

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,10 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
 import { render, screen } from '@testing-library/react';
 import App from '@/pages/_app';
 
+const mockUseAuth = jest.fn();
+
+// Mock auth-context so the RouteGuard doesn't hit real Supabase
+jest.mock('@/lib/auth-context', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => mockUseAuth(),
+}));
+
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: () => ({ pathname: '/', replace: jest.fn(), push: jest.fn() }),
+}));
+
 describe('App', () => {
-  it('renders the page component', () => {
+  it('renders the page component when guest', () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, session: null, isGuest: true });
     const Component = () => <div>Page content</div>;
     render(<App Component={Component} pageProps={{}} />);
     expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+
+  it('suppresses content while auth is loading', () => {
+    mockUseAuth.mockReturnValue({ isLoading: true, session: null, isGuest: false });
+    const Component = () => <div>Protected content</div>;
+    render(<App Component={Component} pageProps={{}} />);
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+
+  it('renders content when authenticated', () => {
+    mockUseAuth.mockReturnValue({
+      isLoading: false,
+      session: { access_token: 'tok' },
+      isGuest: false,
+    });
+    const Component = () => <div>Dashboard</div>;
+    render(<App Component={Component} pageProps={{}} />);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -28,7 +28,7 @@ jest.mock('next/router', () => ({
 
 // Mock supabase-browser (sign-out only used in logout handler)
 jest.mock('@/lib/supabase-browser', () => ({
-  supabaseBrowser: { auth: { signOut: jest.fn().mockResolvedValue({}) } },
+  getSupabaseBrowser: () => ({ auth: { signOut: jest.fn().mockResolvedValue({}) } }),
 }));
 
 // Build a record dated within the last 30 days (default range)

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -13,6 +13,24 @@ jest.mock('@/components/DetailTable', () => ({
   DetailTable: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
+const mockUseAuth = jest.fn();
+
+// Mock auth-context — default: authenticated, ict-manager role
+jest.mock('@/lib/auth-context', () => ({
+  useAuth: () => mockUseAuth(),
+  clearGuestMode: jest.fn(),
+}));
+
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: () => ({ pathname: '/', replace: jest.fn(), push: jest.fn() }),
+}));
+
+// Mock supabase-browser (sign-out only used in logout handler)
+jest.mock('@/lib/supabase-browser', () => ({
+  supabaseBrowser: { auth: { signOut: jest.fn().mockResolvedValue({}) } },
+}));
+
 // Build a record dated within the last 30 days (default range)
 const yesterday = new Date();
 yesterday.setDate(yesterday.getDate() - 1);
@@ -39,6 +57,14 @@ const MOCK_RECORD: TestRecord = {
 };
 
 beforeEach(() => {
+  mockUseAuth.mockReturnValue({
+    session:   { access_token: 'test-jwt' },
+    user:      { id: 'user-1' },
+    role:      'ict-manager',
+    isGuest:   false,
+    isLoading: false,
+  });
+
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ records: [MOCK_RECORD], demo: false }),
@@ -62,16 +88,41 @@ describe('HomePage', () => {
     });
   });
 
-  it('shows demo banner when API returns demo:true', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ records: [MOCK_RECORD], demo: true }),
+  it('sends Authorization header when session is present', async () => {
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect((options?.headers as Record<string, string>)?.['Authorization']).toBe('Bearer test-jwt');
+  });
+
+  it('shows guest banner when isGuest is true', async () => {
+    mockUseAuth.mockReturnValue({
+      session: null, user: null, role: null, isGuest: true, isLoading: false,
     });
 
     render(<HomePage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Demo mode/i)).toBeInTheDocument();
+      expect(screen.getByText(/Guest mode/i)).toBeInTheDocument();
     });
+  });
+
+  it('does not send Authorization header for guests', async () => {
+    mockUseAuth.mockReturnValue({
+      session: null, user: null, role: null, isGuest: true, isLoading: false,
+    });
+
+    render(<HomePage />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+    expect((options?.headers as Record<string, string>)?.['Authorization']).toBeUndefined();
   });
 });

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -1,30 +1,35 @@
 /**
  * GET /api/tests?start=YYYY-MM-DD&end=YYYY-MM-DD
  *
- * Returns TestRecord[] joined across tests + boards + products + test_errors.
- * Falls back to src/fixtures/guest-data.json when SUPABASE_URL is not set.
- * Dates are offset so the most-recent fixture test always appears as today,
- * keeping the default 7-day range useful in demo mode.
+ * Data routing:
+ *   - Authenticated request (Authorization: Bearer <jwt>):
+ *       Queries Supabase using the user's JWT + anon key → RLS enforced.
+ *   - Guest request (no Authorization header):
+ *       Returns src/fixtures/guest-data.json (no Supabase call made).
+ *
+ * Returns { records: TestRecord[], demo: boolean }
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import path from 'path';
 import fs from 'fs';
 import type { TestRecord, TestErrorRecord } from '@/lib/testUtils';
 
 // ---------------------------------------------------------------------------
-// Supabase live path
+// Supabase live path (RLS-enforced via user JWT + anon key)
 // ---------------------------------------------------------------------------
 
-function getSupabase() {
-  const url = process.env.SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_KEY!;
-  return createClient(url, key) as ReturnType<typeof createClient<any, any, any>>;
+function getSupabaseForUser(authHeader: string): SupabaseClient {
+  const url    = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL!;
+  const anon   = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, anon, {
+    global: { headers: { Authorization: authHeader } },
+    auth:   { persistSession: false },
+  }) as SupabaseClient;
 }
 
-async function fetchFromSupabase(start: string, end: string): Promise<TestRecord[]> {
-  const sb = getSupabase();
+async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string): Promise<TestRecord[]> {
   const { data, error } = await sb
     .from('tests')
     .select(`
@@ -62,7 +67,7 @@ async function fetchFromSupabase(start: string, end: string): Promise<TestRecord
 }
 
 // ---------------------------------------------------------------------------
-// Fixture / demo path
+// Fixture / guest path
 // ---------------------------------------------------------------------------
 
 type FixtureData = {
@@ -173,14 +178,19 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'start and end query params are required (YYYY-MM-DD)' }, { status: 400 });
   }
 
-  const usingFixture = !process.env.SUPABASE_URL;
+  const authHeader = req.headers.get('authorization');
 
+  // Guest path — no auth header → return fixture, no Supabase call made
+  if (!authHeader) {
+    const records = fetchFromFixture(start, end);
+    return NextResponse.json({ records, demo: true });
+  }
+
+  // Authenticated path — use user JWT with anon key so RLS is enforced
   try {
-    const records = usingFixture
-      ? fetchFromFixture(start, end)
-      : await fetchFromSupabase(start, end);
-
-    return NextResponse.json({ records, demo: usingFixture });
+    const sb = getSupabaseForUser(authHeader);
+    const records = await fetchFromSupabase(sb, start, end);
+    return NextResponse.json({ records, demo: false });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,0 +1,127 @@
+/**
+ * auth-context.tsx — authentication state for the ICT Data Viewer.
+ *
+ * Provides:
+ *   - session / user  — from Supabase auth
+ *   - role            — fetched via get_my_role() RPC after sign-in
+ *   - isGuest         — true when the user chose "Continue as guest"
+ *   - isLoading       — true until the initial session check completes
+ *
+ * Helper exports:
+ *   - setGuestMode()  — called from the login page "Continue as guest" button
+ *   - clearGuestMode() — called on sign-in and sign-out
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabaseBrowser } from '@/lib/supabase-browser';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AppRole = 'ict-member' | 'ict-manager' | 'ict-admin' | null;
+
+type AuthContextValue = {
+  session: Session | null;
+  user: User | null;
+  role: AppRole;
+  isGuest: boolean;
+  isLoading: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Guest-mode helpers (sessionStorage so it resets on tab close)
+// ---------------------------------------------------------------------------
+
+const GUEST_KEY = 'ict-guest';
+
+export function setGuestMode(): void {
+  if (typeof window !== 'undefined') sessionStorage.setItem(GUEST_KEY, 'true');
+}
+
+export function clearGuestMode(): void {
+  if (typeof window !== 'undefined') sessionStorage.removeItem(GUEST_KEY);
+}
+
+function isGuestStored(): boolean {
+  if (typeof window === 'undefined') return false;
+  return sessionStorage.getItem(GUEST_KEY) === 'true';
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const AuthContext = createContext<AuthContextValue>({
+  session:   null,
+  user:      null,
+  role:      null,
+  isGuest:   false,
+  isLoading: true,
+});
+
+export function useAuth(): AuthContextValue {
+  return useContext(AuthContext);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session,   setSession]   = useState<Session | null>(null);
+  const [user,      setUser]      = useState<User | null>(null);
+  const [role,      setRole]      = useState<AppRole>(null);
+  const [isGuest,   setIsGuest]   = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchRole = useCallback(async () => {
+    const { data, error } = await supabaseBrowser.rpc('get_my_role');
+    if (!error && data) {
+      setRole(data as AppRole);
+    } else {
+      setRole(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Restore existing session on mount
+    void supabaseBrowser.auth.getSession().then(({ data: { session: s } }) => {
+      setSession(s);
+      setUser(s?.user ?? null);
+      setIsGuest(!s && isGuestStored());
+      if (s?.user) void fetchRole();
+      setIsLoading(false);
+    });
+
+    // Subscribe to future auth state changes
+    const { data: { subscription } } = supabaseBrowser.auth.onAuthStateChange(
+      (_event, s) => {
+        setSession(s);
+        setUser(s?.user ?? null);
+        setIsGuest(!s && isGuestStored());
+        if (s?.user) {
+          void fetchRole();
+        } else {
+          setRole(null);
+        }
+        setIsLoading(false);
+      },
+    );
+
+    return () => { subscription.unsubscribe(); };
+  }, [fetchRole]);
+
+  return (
+    <AuthContext.Provider value={{ session, user, role, isGuest, isLoading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -2,13 +2,14 @@
  * auth-context.tsx — authentication state for the ICT Data Viewer.
  *
  * Provides:
- *   - session / user  — from Supabase auth
- *   - role            — fetched via get_my_role() RPC after sign-in
- *   - isGuest         — true when the user chose "Continue as guest"
- *   - isLoading       — true until the initial session check completes
+ *   - session / user    — from Supabase auth
+ *   - role              — fetched via get_my_role() RPC after sign-in
+ *   - isGuest           — true when the user chose "Continue as guest"
+ *   - isLoading         — true until the initial session check completes
+ *   - enterGuestMode()  — call instead of setGuestMode(); updates both
+ *                         sessionStorage and the React state in one step
  *
- * Helper exports:
- *   - setGuestMode()  — called from the login page "Continue as guest" button
+ * Internal helper exports (storage only, no state update):
  *   - clearGuestMode() — called on sign-in and sign-out
  */
 
@@ -34,6 +35,7 @@ type AuthContextValue = {
   role: AppRole;
   isGuest: boolean;
   isLoading: boolean;
+  enterGuestMode: () => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -60,11 +62,12 @@ function isGuestStored(): boolean {
 // ---------------------------------------------------------------------------
 
 const AuthContext = createContext<AuthContextValue>({
-  session:   null,
-  user:      null,
-  role:      null,
-  isGuest:   false,
-  isLoading: true,
+  session:        null,
+  user:           null,
+  role:           null,
+  isGuest:        false,
+  isLoading:      true,
+  enterGuestMode: () => {},
 });
 
 export function useAuth(): AuthContextValue {
@@ -81,6 +84,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [role,      setRole]      = useState<AppRole>(null);
   const [isGuest,   setIsGuest]   = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+
+  const enterGuestMode = useCallback(() => {
+    setGuestMode();
+    setIsGuest(true);
+  }, []);
 
   const fetchRole = useCallback(async () => {
     const { data, error } = await getSupabaseBrowser().rpc('get_my_role');
@@ -120,7 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchRole]);
 
   return (
-    <AuthContext.Provider value={{ session, user, role, isGuest, isLoading }}>
+    <AuthContext.Provider value={{ session, user, role, isGuest, isLoading, enterGuestMode }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -20,7 +20,7 @@ import React, {
   useState,
 } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { getSupabaseBrowser } from '@/lib/supabase-browser';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -83,7 +83,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchRole = useCallback(async () => {
-    const { data, error } = await supabaseBrowser.rpc('get_my_role');
+    const { data, error } = await getSupabaseBrowser().rpc('get_my_role');
     if (!error && data) {
       setRole(data as AppRole);
     } else {
@@ -93,7 +93,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     // Restore existing session on mount
-    void supabaseBrowser.auth.getSession().then(({ data: { session: s } }) => {
+    void getSupabaseBrowser().auth.getSession().then(({ data: { session: s } }) => {
       setSession(s);
       setUser(s?.user ?? null);
       setIsGuest(!s && isGuestStored());
@@ -102,7 +102,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
 
     // Subscribe to future auth state changes
-    const { data: { subscription } } = supabaseBrowser.auth.onAuthStateChange(
+    const { data: { subscription } } = getSupabaseBrowser().auth.onAuthStateChange(
       (_event, s) => {
         setSession(s);
         setUser(s?.user ?? null);

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,0 +1,14 @@
+/**
+ * supabase-browser.ts — browser-side Supabase singleton.
+ *
+ * Uses the public anon key (safe to expose; RLS enforces access).
+ * Do NOT import this in server-only modules (API routes, ict-db.ts).
+ * For server-side admin operations, see ict-db.ts (service role key).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const url  = process.env.NEXT_PUBLIC_SUPABASE_URL  ?? '';
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+export const supabaseBrowser = createClient(url, anon);

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -6,9 +6,16 @@
  * For server-side admin operations, see ict-db.ts (service role key).
  */
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const url  = process.env.NEXT_PUBLIC_SUPABASE_URL  ?? '';
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+let _instance: SupabaseClient | null = null;
 
-export const supabaseBrowser = createClient(url, anon);
+/** Returns the browser-side Supabase singleton (created on first call). */
+export function getSupabaseBrowser(): SupabaseClient {
+  if (!_instance) {
+    const url  = process.env.NEXT_PUBLIC_SUPABASE_URL  ?? '';
+    const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+    _instance = createClient(url, anon);
+  }
+  return _instance;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,34 @@
 import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import '@/styles/globals.css';
+import { AuthProvider, useAuth } from '@/lib/auth-context';
+
+/** Redirects unauthenticated, non-guest users to /login. */
+function RouteGuard({ children }: { children: React.ReactNode }) {
+  const { isLoading, session, isGuest } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!session && !isGuest && router.pathname !== '/login') {
+      void router.replace('/login');
+    }
+  }, [isLoading, session, isGuest, router]);
+
+  // Suppress flash of protected content while redirecting
+  if (isLoading) return null;
+  if (!session && !isGuest && router.pathname !== '/login') return null;
+
+  return <>{children}</>;
+}
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <RouteGuard>
+        <Component {...pageProps} />
+      </RouteGuard>
+    </AuthProvider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import { ChartPanel, type ChartDataset } from '@/components/ChartPanel';
 import { DetailTable } from '@/components/DetailTable';
 import { FilterPanel } from '@/components/FilterPanel';
 import { StatusBanner } from '@/components/StatusBanner';
+import { clearGuestMode, useAuth } from '@/lib/auth-context';
+import { supabaseBrowser } from '@/lib/supabase-browser';
 import {
   buildErrorCounts,
   buildSummary,
@@ -32,8 +35,10 @@ const METRIC_FIELD: MetricToField = {
 };
 
 export default function HomePage() {
+  const router = useRouter();
+  const { session, role, isGuest } = useAuth();
+
   const [records, setRecords] = useState<TestRecord[]>([]);
-  const [demoMode, setDemoMode] = useState(false);
   const [status, setStatus] = useState<string | null>('Loading data...');
   const [rangePreset, setRangePreset] = useState('30');
   const [startDate, setStartDate] = useState('');
@@ -48,20 +53,25 @@ export default function HomePage() {
     if (!start || !end) return;
     try {
       setStatus('Loading data...');
-      const res = await fetch(`/api/tests?start=${start}&end=${end}`);
+
+      const headers: Record<string, string> = {};
+      if (session?.access_token) {
+        headers['Authorization'] = `Bearer ${session.access_token}`;
+      }
+
+      const res = await fetch(`/api/tests?start=${start}&end=${end}`, { headers });
       if (!res.ok) {
         const body = (await res.json()) as { error?: string };
         throw new Error(body.error ?? `HTTP ${res.status}`);
       }
       const body = (await res.json()) as { records: TestRecord[]; demo: boolean };
       setRecords(body.records);
-      setDemoMode(body.demo);
       setStatus(null);
     } catch (err) {
       setStatus(err instanceof Error ? err.message : 'Unable to load data.');
       setRecords([]);
     }
-  }, []);
+  }, [session]);
 
   useEffect(() => {
     const rangeDays = Number(rangePreset);
@@ -76,6 +86,12 @@ export default function HomePage() {
       void loadData(s, e);
     }
   }, [rangePreset, loadData]);
+
+  async function handleLogout() {
+    await supabaseBrowser.auth.signOut();
+    clearGuestMode();
+    void router.push('/login');
+  }
 
   const activeRange = useMemo(() => {
     if (!startDate || !endDate) return null;
@@ -202,16 +218,47 @@ export default function HomePage() {
     status ??
     (rowsInRange.length === 0 && records.length > 0 ? 'No records match the selected range.' : null);
 
+  // Show AI chat entry point for ict-manager and ict-admin only.
+  // TODO: implement AI chat feature here — replace the placeholder below.
+  const showAiChat = !isGuest && role !== null && role !== 'ict-member';
+
   return (
     <main>
       <header>
         <div>
           <h1>ICT Data Viewer</h1>
           <p>Visualize ICT board test results from Supabase.</p>
-          {demoMode && (
+          {isGuest && (
             <p style={{ color: '#f59e0b', fontWeight: 'bold' }}>
-              Demo mode: Showing guest fixture data. Set SUPABASE_URL to load real data.
+              Guest mode: Showing demo fixture data.{' '}
+              <a href="/login" style={{ color: '#f59e0b' }}>Sign in</a> for live data.
             </p>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          {/* TODO: AI chat entry point — place chat button/panel here.
+              Visible to ict-manager and ict-admin only (see showAiChat flag). */}
+          {showAiChat && (
+            <span style={{ fontSize: '13px', color: '#6b7280' }}>{/* AI chat placeholder */}</span>
+          )}
+
+          {!isGuest && (
+            <button
+              type="button"
+              onClick={() => { void handleLogout(); }}
+              style={{
+                background: 'none',
+                border: '1px solid #e2e8f0',
+                borderRadius: '6px',
+                padding: '6px 12px',
+                cursor: 'pointer',
+                fontSize: '13px',
+                color: '#4b5563',
+              }}
+            >
+              Log out
+            </button>
           )}
         </div>
       </header>
@@ -271,7 +318,7 @@ export default function HomePage() {
       />
 
       <footer>
-        Data source: Supabase. The app reads test records live.
+        Data source: {isGuest ? 'Demo fixture data' : 'Supabase'}. The app reads test records live.
       </footer>
     </main>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import { DetailTable } from '@/components/DetailTable';
 import { FilterPanel } from '@/components/FilterPanel';
 import { StatusBanner } from '@/components/StatusBanner';
 import { clearGuestMode, useAuth } from '@/lib/auth-context';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import {
   buildErrorCounts,
   buildSummary,
@@ -88,7 +88,7 @@ export default function HomePage() {
   }, [rangePreset, loadData]);
 
   async function handleLogout() {
-    await supabaseBrowser.auth.signOut();
+    await getSupabaseBrowser().auth.signOut();
     clearGuestMode();
     void router.push('/login');
   }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { supabaseBrowser } from '@/lib/supabase-browser';
+import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import { clearGuestMode, setGuestMode, useAuth } from '@/lib/auth-context';
 
 export default function LoginPage() {
@@ -24,7 +24,7 @@ export default function LoginPage() {
     setPending(true);
     setError(null);
 
-    const { error: authError } = await supabaseBrowser.auth.signInWithPassword({
+    const { error: authError } = await getSupabaseBrowser().auth.signInWithPassword({
       email: email.trim(),
       password,
     });

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
-import { clearGuestMode, setGuestMode, useAuth } from '@/lib/auth-context';
+import { clearGuestMode, useAuth } from '@/lib/auth-context';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { session, isLoading } = useAuth();
+  const { session, isLoading, enterGuestMode } = useAuth();
 
   const [email,    setEmail]    = useState('');
   const [password, setPassword] = useState('');
@@ -39,7 +39,7 @@ export default function LoginPage() {
   }
 
   function handleGuest() {
-    setGuestMode();
+    enterGuestMode();
     void router.replace('/');
   }
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabaseBrowser } from '@/lib/supabase-browser';
+import { clearGuestMode, setGuestMode, useAuth } from '@/lib/auth-context';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { session, isLoading } = useAuth();
+
+  const [email,    setEmail]    = useState('');
+  const [password, setPassword] = useState('');
+  const [error,    setError]    = useState<string | null>(null);
+  const [pending,  setPending]  = useState(false);
+
+  // Already authenticated — go straight to the dashboard
+  useEffect(() => {
+    if (!isLoading && session) {
+      void router.replace('/');
+    }
+  }, [isLoading, session, router]);
+
+  async function handleSignIn(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+
+    const { error: authError } = await supabaseBrowser.auth.signInWithPassword({
+      email: email.trim(),
+      password,
+    });
+
+    if (authError) {
+      setError(authError.message);
+      setPending(false);
+    } else {
+      clearGuestMode();
+      void router.replace('/');
+    }
+  }
+
+  function handleGuest() {
+    setGuestMode();
+    void router.replace('/');
+  }
+
+  return (
+    <div className="login-container">
+      <div className="login-card">
+        <h1 className="login-title">ICT Data Viewer</h1>
+        <p className="login-subtitle">Sign in to view live test data</p>
+
+        <form onSubmit={(e) => { void handleSignIn(e); }} noValidate>
+          <div className="login-field">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); }}
+              required
+              disabled={pending}
+            />
+          </div>
+
+          <div className="login-field">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); }}
+              required
+              disabled={pending}
+            />
+          </div>
+
+          {error && (
+            <p className="login-error" role="alert">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={pending || !email || !password}
+          >
+            {pending ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+
+        {/* No sign-up — accounts are admin-managed */}
+
+        <div className="login-divider" />
+
+        <button
+          type="button"
+          className="btn-guest"
+          onClick={handleGuest}
+        >
+          Continue as guest
+        </button>
+        <p className="login-guest-note">Guest mode shows demo fixture data only.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -178,6 +178,127 @@ footer {
   padding: 20px 32px 40px;
 }
 
+/* ---------------------------------------------------------------------------
+   Login page
+   --------------------------------------------------------------------------- */
+
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.login-card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 40px 36px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.07);
+}
+
+.login-title {
+  margin: 0 0 4px;
+  font-size: 22px;
+}
+
+.login-subtitle {
+  margin: 0 0 28px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.login-field {
+  margin-bottom: 16px;
+}
+
+.login-field label {
+  display: block;
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.login-field input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.login-field input:focus {
+  border-color: #2563eb;
+}
+
+.login-error {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  border-radius: 8px;
+  color: #991b1b;
+  font-size: 13px;
+}
+
+.btn-primary {
+  width: 100%;
+  padding: 10px;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-top: 4px;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.login-divider {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 24px 0 20px;
+}
+
+.btn-guest {
+  width: 100%;
+  padding: 9px;
+  background: none;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.btn-guest:hover {
+  border-color: #9ca3af;
+  background: #f9fafb;
+}
+
+.login-guest-note {
+  margin: 8px 0 0;
+  text-align: center;
+  font-size: 12px;
+  color: #9ca3af;
+}
+
 @media (max-width: 900px) {
   .chart-section {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
Implements user authentication and guest mode for the ICT Data Viewer using Supabase Auth. Authenticated users can sign in with email/password and access live data via RLS-enforced queries, while guests can view demo fixture data without authentication.

## Key Changes

- **Auth Context** (`src/lib/auth-context.tsx`): New React context providing session, user, role, and guest-mode state. Includes helpers for managing guest mode via sessionStorage.

- **Login Page** (`src/pages/login.tsx`): New dedicated login page with email/password sign-in form and "Continue as guest" button. Redirects authenticated users to dashboard.

- **Route Guard** (`src/pages/_app.tsx`): Wraps the app with `AuthProvider` and `RouteGuard` to enforce authentication. Unauthenticated, non-guest users are redirected to `/login`.

- **Browser Supabase Client** (`src/lib/supabase-browser.ts`): New singleton using the public anon key for client-side auth and RLS-enforced queries.

- **API Data Routing** (`src/app/api/tests/route.ts`): 
  - Authenticated requests (with JWT in Authorization header) query Supabase with RLS enforced
  - Guest requests (no Authorization header) return fixture data without Supabase call
  - Replaced demo-mode flag logic with explicit guest/authenticated paths

- **Dashboard Updates** (`src/pages/index.tsx`):
  - Sends JWT in Authorization header for authenticated requests
  - Shows guest banner with sign-in link when in guest mode
  - Adds logout button for authenticated users
  - Placeholder for AI chat feature (visible to ict-manager and ict-admin roles only)

- **Styling** (`src/styles/globals.css`): New login page styles including form fields, buttons, error messages, and guest mode note.

- **Tests**: Updated test mocks to support auth context and added test cases for Authorization header handling and guest mode behavior.

- **Environment Config** (`.env.example`): Added `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` for browser-side auth.

## Implementation Details

- Guest mode is stored in sessionStorage and cleared on sign-in/sign-out, resetting when the tab closes
- User role is fetched via `get_my_role()` RPC after authentication
- API endpoint uses the user's JWT with the anon key to enforce Supabase RLS policies
- No sign-up flow — accounts are admin-managed only

https://claude.ai/code/session_01NnEQ2VJdfv3XBE8t2mbWNn