### PR TITLE
Add AI-powered natural language chat API for board test queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Ingest authentication — arbitrary shared secret; must match apiSecret in ict-ingest.config.json
 INGEST_SECRET=your-ingest-secret
+
+# Anthropic API key — required for the NL→SQL→Answer chat endpoint (/api/chat)
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/READ_ONLY_ROLE_SETUP.md
+++ b/READ_ONLY_ROLE_SETUP.md
@@ -1,0 +1,108 @@
+# Read-Only Role & `execute_readonly_query` Setup
+
+Paste the SQL blocks below into the **Supabase SQL editor** (project `maktqbmsfjkyjpyjgtzv`) in order.
+
+---
+
+## Step 1 — Create the `ict_readonly` role
+
+```sql
+-- Create a role with no login, no superuser, no create-db rights.
+CREATE ROLE ict_readonly NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE;
+
+-- Grant SELECT on every existing table in the public schema.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO ict_readonly;
+
+-- Automatically grant SELECT on any tables created in the future.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO ict_readonly;
+```
+
+---
+
+## Step 2 — Create the `execute_readonly_query` function
+
+```sql
+CREATE OR REPLACE FUNCTION execute_readonly_query(query TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER          -- runs as the function owner (postgres / service role)
+SET search_path = public
+AS $$
+DECLARE
+  result JSONB;
+BEGIN
+  -- Safety check: only allow SELECT statements.
+  IF query !~* '^\s*SELECT\b' THEN
+    RAISE EXCEPTION 'Only SELECT statements are allowed. Got: %', LEFT(query, 80);
+  END IF;
+
+  -- Switch to the read-only role for the duration of this transaction.
+  SET LOCAL ROLE ict_readonly;
+
+  -- Execute the query and aggregate rows into a JSON array.
+  EXECUTE format(
+    'SELECT jsonb_agg(row_to_json(q)) FROM (%s) q',
+    query
+  ) INTO result;
+
+  -- Return [] instead of NULL when the query matches no rows.
+  RETURN COALESCE(result, '[]'::JSONB);
+END;
+$$;
+```
+
+---
+
+## Step 3 — Grant `EXECUTE` to the `anon` role
+
+```sql
+-- The anon role is used by unauthenticated requests (and the chat API route
+-- which passes the anon key).
+GRANT EXECUTE ON FUNCTION execute_readonly_query(TEXT) TO anon;
+```
+
+---
+
+## Step 4 — Verification queries
+
+**Confirm the function returns data:**
+```sql
+SELECT execute_readonly_query(
+  'SELECT COUNT(*) AS total_tests FROM tests'
+);
+-- Expected: [{"total_tests": <number>}]
+```
+
+**Confirm a DELETE is rejected:**
+```sql
+SELECT execute_readonly_query(
+  'DELETE FROM tests WHERE false'
+);
+-- Expected: ERROR: Only SELECT statements are allowed. Got: DELETE FROM tests WHERE false
+```
+
+---
+
+## Step 5 — `.env.local` variables
+
+Add these to your local `.env.local` file (never commit this file):
+
+```dotenv
+NEXT_PUBLIC_SUPABASE_URL=https://maktqbmsfjkyjpyjgtzv.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+ANTHROPIC_API_KEY=<your-anthropic-api-key>
+```
+
+> **Where to find the anon key:** Supabase dashboard → Project Settings → API → `anon` `public` key.
+
+---
+
+## Step 6 — Safety layers summary
+
+| Layer | Where | What it does |
+|-------|-------|--------------|
+| **Pass 1 prompt instruction** | `src/lib/ict-prompt.ts` — `PASS1_SYSTEM_PROMPT` | Instructs Claude to output only SELECT SQL; responds `CANNOT_ANSWER` for out-of-scope questions |
+| **Regex guard in route** | `src/app/api/chat/route.ts` — `guardSql()` | Rejects any SQL that does not start with `SELECT` or contains a mutation keyword before any DB call; returns HTTP 400 |
+| **Function-level SELECT check** | `execute_readonly_query` Postgres function | Raises a Postgres exception if the query string does not start with `SELECT`, preventing execution entirely |
+| **`ict_readonly` role permissions** | Postgres role set via `SET LOCAL ROLE` | Database-level enforcement: the role has only `SELECT` privileges on all tables; no `INSERT/UPDATE/DELETE/DDL` possible even if the other layers are bypassed |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ict-data-viewer",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
         "@supabase/supabase-js": "^2.99.1",
         "chart.js": "^4.5.1",
         "next": "^16.1.6",
@@ -35,6 +36,36 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2591,6 +2622,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
@@ -3202,6 +3243,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3233,6 +3286,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3502,6 +3567,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3764,7 +3835,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4005,6 +4075,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4230,6 +4312,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4285,7 +4376,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4426,7 +4516,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4436,7 +4525,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4474,7 +4562,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4487,7 +4574,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5001,6 +5087,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5228,6 +5323,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5254,7 +5384,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5325,7 +5454,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5360,7 +5488,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5509,7 +5636,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5603,7 +5729,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5616,7 +5741,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5632,7 +5756,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5714,6 +5837,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -7684,7 +7816,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7719,6 +7850,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -7778,7 +7930,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7880,6 +8031,68 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -10056,6 +10269,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@supabase/supabase-js": "^2.99.1",
     "chart.js": "^4.5.1",
     "next": "^16.1.6",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,229 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  PASS1_SYSTEM_PROMPT,
+  PASS2_SYSTEM_PROMPT,
+  buildPass2UserMessage,
+} from '@/lib/ict-prompt';
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const MODEL = 'claude-sonnet-4-20250514';
+const MAX_TOKENS = 1024;
+
+const MUTATION_RE =
+  /\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|EXECUTE)\b/i;
+
+const OUT_OF_SCOPE_RESPONSE = {
+  answer:
+    'I can only answer questions about board test data — boards, tests, failures, errors, fixtures, testers, or operators.',
+  chartable: false,
+  chart_type: 'none' as const,
+  chart_config: { x_key: '', y_key: '', highlight_key: null },
+  rows: [] as object[],
+};
+
+const RETRY_RESPONSE = {
+  answer:
+    "I wasn't able to answer that question. Please try rephrasing it.",
+  chartable: false,
+  chart_type: 'none' as const,
+  chart_config: { x_key: '', y_key: '', highlight_key: null },
+  rows: [] as object[],
+};
+
+async function callPass1(messages: Anthropic.MessageParam[]): Promise<string> {
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: MAX_TOKENS,
+    system: PASS1_SYSTEM_PROMPT,
+    messages,
+  });
+  const block = response.content[0];
+  if (block.type !== 'text') throw new Error('Unexpected non-text response from Pass 1');
+  return block.text.trim();
+}
+
+function guardSql(sql: string): void {
+  if (!/^SELECT\b/i.test(sql)) {
+    throw new Error(`SQL safety guard failed: query does not start with SELECT`);
+  }
+  if (MUTATION_RE.test(sql)) {
+    throw new Error(`SQL safety guard failed: query contains a forbidden keyword`);
+  }
+}
+
+async function runQuery(sql: string): Promise<object[]> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase environment variables are not configured');
+  }
+
+  const resp = await fetch(
+    `${supabaseUrl}/rest/v1/rpc/execute_readonly_query`,
+    {
+      method: 'POST',
+      headers: {
+        apikey: supabaseAnonKey,
+        Authorization: `Bearer ${supabaseAnonKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: sql }),
+    }
+  );
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text);
+  }
+
+  return resp.json() as Promise<object[]>;
+}
+
+interface Pass2Result {
+  answer: string;
+  chartable: boolean;
+  chart_type: 'bar' | 'line' | 'none';
+  chart_config: {
+    x_key: string;
+    y_key: string;
+    highlight_key: string | null;
+  };
+}
+
+function stripFences(text: string): string {
+  return text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).question !== 'string' ||
+    !(body as Record<string, unknown>).question
+  ) {
+    return NextResponse.json(
+      { error: 'Request body must include a non-empty "question" string' },
+      { status: 400 }
+    );
+  }
+
+  const question = ((body as Record<string, unknown>).question as string).trim();
+  const isDev = process.env.NODE_ENV === 'development';
+
+  // ── Pass 1: generate SQL ──────────────────────────────────────────────────
+  let sql: string;
+  try {
+    sql = await callPass1([{ role: 'user', content: question }]);
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Pass 1 failed: ${(err as Error).message}` },
+      { status: 502 }
+    );
+  }
+
+  // ── CANNOT_ANSWER shortcircuit ────────────────────────────────────────────
+  if (sql === 'CANNOT_ANSWER') {
+    return NextResponse.json(OUT_OF_SCOPE_RESPONSE);
+  }
+
+  // ── Safety guard ──────────────────────────────────────────────────────────
+  try {
+    guardSql(sql);
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 400 });
+  }
+
+  // ── Execute query (with one self-healing retry) ───────────────────────────
+  let rows: object[];
+  try {
+    rows = await runQuery(sql);
+  } catch (firstErr) {
+    const errorMessage = (firstErr as Error).message;
+
+    // Self-healing: ask Claude for a corrected query
+    let retrySql: string;
+    try {
+      retrySql = await callPass1([
+        { role: 'user', content: question },
+        { role: 'assistant', content: sql },
+        {
+          role: 'user',
+          content: `Question: ${question}\n\nThe previous SQL attempt failed with this error:\n${errorMessage}\n\nPlease generate a corrected SQL query.`,
+        },
+      ]);
+    } catch {
+      return NextResponse.json(RETRY_RESPONSE);
+    }
+
+    if (retrySql === 'CANNOT_ANSWER') {
+      return NextResponse.json(OUT_OF_SCOPE_RESPONSE);
+    }
+
+    try {
+      guardSql(retrySql);
+    } catch {
+      return NextResponse.json(RETRY_RESPONSE);
+    }
+
+    try {
+      rows = await runQuery(retrySql);
+      sql = retrySql;
+    } catch {
+      return NextResponse.json(RETRY_RESPONSE);
+    }
+  }
+
+  // ── Pass 2: generate answer + chart config ────────────────────────────────
+  let pass2Result: Pass2Result;
+  try {
+    const pass2Response = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      system: PASS2_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: buildPass2UserMessage({ question, sql, rows }),
+        },
+      ],
+    });
+
+    const block = pass2Response.content[0];
+    if (block.type !== 'text') throw new Error('Unexpected non-text response from Pass 2');
+
+    const cleaned = stripFences(block.text);
+    pass2Result = JSON.parse(cleaned) as Pass2Result;
+  } catch (err) {
+    // If Pass 2 or JSON parse fails, return raw text with safe defaults
+    const rawText =
+      err instanceof SyntaxError
+        ? 'Unable to parse structured response.'
+        : (err as Error).message;
+    return NextResponse.json({
+      answer: rawText,
+      chartable: false,
+      chart_type: 'none' as const,
+      chart_config: { x_key: '', y_key: '', highlight_key: null },
+      rows: isDev ? rows! : [],
+      ...(isDev ? { sql } : {}),
+    });
+  }
+
+  return NextResponse.json({
+    answer: pass2Result.answer,
+    chartable: pass2Result.chartable,
+    chart_type: pass2Result.chart_type,
+    chart_config: pass2Result.chart_config,
+    rows,
+    ...(isDev ? { sql } : {}),
+  });
+}

--- a/src/lib/ict-prompt.ts
+++ b/src/lib/ict-prompt.ts
@@ -1,0 +1,139 @@
+export const SCHEMA_CONTEXT = `
+Database schema (PostgreSQL via Supabase):
+
+products(
+  id          UUID PRIMARY KEY,
+  part_number TEXT NOT NULL,
+  product_name TEXT NOT NULL
+)
+
+boards(
+  id            UUID PRIMARY KEY,
+  serial_number TEXT NOT NULL,
+  mac_address   TEXT,
+  rev           TEXT,
+  product_id    UUID REFERENCES products(id)
+)
+
+tests(
+  id          UUID PRIMARY KEY,
+  board_id    UUID REFERENCES boards(id),
+  start_time  TIMESTAMPTZ NOT NULL,
+  end_time    TIMESTAMPTZ,
+  operator_id TEXT,
+  fixture_id  TEXT,
+  tester      TEXT,
+  result      TEXT NOT NULL,   -- enum: 'pass' | 'fail'
+  source_file TEXT,
+  ingested_at TIMESTAMPTZ
+)
+
+test_errors(
+  id                UUID PRIMARY KEY,
+  test_id           UUID REFERENCES tests(id),
+  error_type        TEXT NOT NULL,   -- enum: 'analog' | 'digital_pin' | 'shorts_report' | 'unknown'
+  location          TEXT,
+  subtest           TEXT,
+  part_spec         TEXT,
+  unit              TEXT,
+  measured_raw      TEXT,
+  measured_value    FLOAT,   -- base SI units
+  nominal_raw       TEXT,
+  nominal_value     FLOAT,   -- base SI units
+  high_limit_raw    TEXT,
+  high_limit_value  FLOAT,   -- base SI units
+  low_limit_raw     TEXT,
+  low_limit_value   FLOAT,   -- base SI units
+  threshold_raw     TEXT,
+  threshold_value   FLOAT    -- base SI units
+)
+
+Key relationships:
+- test_errors → tests (via test_id)
+- tests → boards (via board_id)
+- boards → products (via product_id)
+`.trim();
+
+export const PASS1_SYSTEM_PROMPT = `You are a PostgreSQL query generator for an ICT (In-Circuit Test) board test database.
+
+${SCHEMA_CONTEXT}
+
+RULES:
+1. Output ONLY a raw SELECT SQL statement. No markdown, no backticks, no explanation. The very first character of your response must be the letter S.
+2. Never use these keywords: INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, TRUNCATE, GRANT, REVOKE, EXECUTE
+3. Always include LIMIT 200 at the end of the query — UNLESS the question produces exactly one aggregate row (e.g. a single COUNT or AVG with no GROUP BY).
+4. When a time range is ambiguous or not specified, default to the last 30 days: start_time >= NOW() - INTERVAL '30 days'
+5. Join path when going from errors to boards/products: test_errors → tests → boards → products
+6. Failure rate formula: COUNT(*) FILTER (WHERE result='fail') * 100.0 / COUNT(*)
+7. If the question is completely outside the scope of board test data, output exactly: CANNOT_ANSWER
+
+EXAMPLES:
+
+Question: How many failures occurred per board per week?
+SQL: SELECT b.serial_number, DATE_TRUNC('week', t.start_time) AS week, COUNT(*) FILTER (WHERE t.result='fail') AS failures FROM tests t JOIN boards b ON b.id = t.board_id WHERE t.start_time >= NOW() - INTERVAL '30 days' GROUP BY b.serial_number, week ORDER BY week DESC, failures DESC LIMIT 200
+
+Question: What is the failure rate by fixture for the last 30 days?
+SQL: SELECT fixture_id, COUNT(*) FILTER (WHERE result='fail') * 100.0 / COUNT(*) AS failure_rate, COUNT(*) AS total_tests FROM tests WHERE start_time >= NOW() - INTERVAL '30 days' GROUP BY fixture_id ORDER BY failure_rate DESC LIMIT 200
+
+Question: How many analog errors has each tester seen?
+SQL: SELECT t.tester, COUNT(*) AS analog_error_count FROM test_errors te JOIN tests t ON t.id = te.test_id WHERE te.error_type = 'analog' AND t.start_time >= NOW() - INTERVAL '30 days' GROUP BY t.tester ORDER BY analog_error_count DESC LIMIT 200
+
+Question: Show failure rate broken down by fixture and tester combo.
+SQL: SELECT fixture_id, tester, COUNT(*) FILTER (WHERE result='fail') * 100.0 / COUNT(*) AS failure_rate, COUNT(*) AS total FROM tests WHERE start_time >= NOW() - INTERVAL '30 days' GROUP BY fixture_id, tester ORDER BY failure_rate DESC LIMIT 200
+
+Question: Which testers see errors at location U14?
+SQL: SELECT DISTINCT t.tester FROM test_errors te JOIN tests t ON t.id = te.test_id WHERE te.location = 'U14' AND t.start_time >= NOW() - INTERVAL '30 days' LIMIT 200
+
+Question: Give me error count broken down by location and error type.
+SQL: SELECT te.location, te.error_type, COUNT(*) AS error_count FROM test_errors te JOIN tests t ON t.id = te.test_id WHERE t.start_time >= NOW() - INTERVAL '30 days' GROUP BY te.location, te.error_type ORDER BY error_count DESC LIMIT 200
+
+Question: Show failure trends by location grouped by week for the last 60 days.
+SQL: SELECT te.location, DATE_TRUNC('week', t.start_time) AS week, COUNT(*) AS error_count FROM test_errors te JOIN tests t ON t.id = te.test_id WHERE t.start_time >= NOW() - INTERVAL '60 days' GROUP BY te.location, week ORDER BY week DESC, error_count DESC LIMIT 200
+
+Question: Look up board with serial number SN-1234.
+SQL: SELECT b.serial_number, b.mac_address, b.rev, p.part_number, p.product_name FROM boards b JOIN products p ON p.id = b.product_id WHERE b.serial_number = 'SN-1234' LIMIT 200
+
+Question: What is the weather today?
+SQL: CANNOT_ANSWER`;
+
+export const PASS2_SYSTEM_PROMPT = `You are a data analyst summarising ICT board test query results for hardware engineers.
+
+RULES:
+1. Return ONLY a valid JSON object. No markdown, no backticks, no explanation. The response must start with { and end with }.
+2. JSON shape:
+{
+  "answer": string,
+  "chartable": boolean,
+  "chart_type": "bar" | "line" | "none",
+  "chart_config": {
+    "x_key": string,
+    "y_key": string,
+    "highlight_key": string | null
+  }
+}
+
+3. chart_type selection rules:
+   - "line": rows contain a date or timestamp column AND one numeric column
+   - "bar": rows contain a categorical column (fixture_id, tester, error_type, location, part_spec, etc.) AND one numeric column
+   - "none": single row result, mixed types with no clear axis, or no meaningful chart possible — also set chartable: false
+
+4. highlight_key: set to the string value of the x_key column for the most significant outlier (e.g. the fixture with the highest failure rate). Set to null if there is no clear outlier or chart_type is "none".
+
+5. answer rules:
+   - Base your answer strictly on the provided rows. Never invent numbers.
+   - Keep it 1–3 sentences in plain English suitable for a hardware engineer.
+   - If rows is empty: explain the likely cause (no data in the time range, possible typo in a filter value, or no failures in the period) — do not say "I don't know".
+   - If the result list has more than 10 items: summarise the top items and note the total count.
+   - Explicitly call out clear patterns (e.g. a single fixture dominating failures, a tester with unusually high error counts).`;
+
+export function buildPass2UserMessage({
+  question,
+  sql,
+  rows,
+}: {
+  question: string;
+  sql: string;
+  rows: object[];
+}): string {
+  return `Question: ${question}\n\nSQL executed:\n${sql}\n\nRows returned (${rows.length}):\n${JSON.stringify(rows, null, 2)}`;
+}


### PR DESCRIPTION
## Summary
Adds a new `/api/chat` endpoint that enables natural language queries against the board test database using Claude AI. The system uses a two-pass approach: first generating SQL from the user's question, then synthesizing a human-readable answer with optional chart configuration from the query results.

## Key Changes

- **New chat API endpoint** (`src/app/api/chat/route.ts`):
  - Implements a two-pass Claude-based query pipeline (Pass 1: NL→SQL, Pass 2: results→answer)
  - Includes SQL safety guards (regex validation + function-level checks) to prevent mutations
  - Implements self-healing retry logic: if a query fails, Claude attempts to correct it based on the error
  - Returns structured JSON with answer text, chart metadata, and query results
  - Development mode includes raw SQL and full result rows for debugging

- **Prompt templates and schema context** (`src/lib/ict-prompt.ts`):
  - `PASS1_SYSTEM_PROMPT`: Instructs Claude to generate SELECT-only SQL with schema context and examples
  - `PASS2_SYSTEM_PROMPT`: Guides Claude to produce structured JSON with answer + chart configuration
  - `SCHEMA_CONTEXT`: Documents the board test database schema (products, boards, tests, test_errors)
  - Helper function `buildPass2UserMessage()` to format query results for Pass 2

- **Database setup documentation** (`READ_ONLY_ROLE_SETUP.md`):
  - SQL scripts to create `ict_readonly` role with SELECT-only permissions
  - `execute_readonly_query()` Postgres function that enforces SELECT-only execution at the database level
  - Verification queries and environment variable setup instructions
  - Summary table of all safety layers (prompt, regex guard, function check, role permissions)

- **Dependencies**:
  - Added `@anthropic-ai/sdk` for Claude API integration
  - Updated `.env.example` with `ANTHROPIC_API_KEY` documentation

## Notable Implementation Details

- **Multi-layer safety**: SQL safety is enforced at four levels—prompt instruction, regex guard, Postgres function, and role-based permissions—to prevent accidental or malicious mutations
- **Self-healing queries**: If a query fails (e.g., schema mismatch), Claude is given the error and asked to generate a corrected query, improving robustness
- **Scope enforcement**: Pass 1 can respond with `CANNOT_ANSWER` for questions outside the board test domain
- **Chart-aware responses**: Pass 2 determines whether results are chartable (line/bar/none) and provides x/y keys and highlight suggestions for visualization
- **Development debugging**: In development mode, the response includes the generated SQL and full result rows for inspection

https://claude.ai/code/session_014Qh2omGvWEt8Y2PpKkEXSW