### PR TITLE
Add interactive summary filters and refactor header layout

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -19,7 +19,6 @@ type FilterPanelProps = {
 };
 
 export function FilterPanel({
-  onReload,
   rangePreset,
   onRangePresetChange,
   startDate,
@@ -36,18 +35,12 @@ export function FilterPanel({
   onErrorToggle
 }: FilterPanelProps) {
   return (
-    <section className="section controls">
-      <div className="card control-card">
-        <label>Data source</label>
-        <button type="button" onClick={onReload}>
-          Reload data
-        </button>
-        <p style={{ margin: '8px 0 0', color: '#6b7280' }}>Loading data.</p>
-      </div>
-      <div className="card control-card">
-        <label htmlFor="range-select">Date range</label>
+    <>
+      <span className="header-control-group">
+        <label className="header-label" htmlFor="range-select">Date Range</label>
         <select
           id="range-select"
+          className="header-select"
           value={rangePreset}
           onChange={(event) => onRangePresetChange(event.target.value)}
         >
@@ -57,30 +50,31 @@ export function FilterPanel({
           <option value="custom">Custom</option>
         </select>
         {rangePreset === 'custom' ? (
-          <div className="custom-range">
-            <label>
-              Start
-              <input
-                type="date"
-                value={startDate}
-                onChange={(event) => onStartDateChange(event.target.value)}
-              />
-            </label>
-            <label>
-              End
-              <input
-                type="date"
-                value={endDate}
-                onChange={(event) => onEndDateChange(event.target.value)}
-              />
-            </label>
-          </div>
+          <>
+            <input
+              type="date"
+              className="header-select"
+              value={startDate}
+              onChange={(event) => onStartDateChange(event.target.value)}
+              aria-label="Start date"
+            />
+            <span className="header-label">–</span>
+            <input
+              type="date"
+              className="header-select"
+              value={endDate}
+              onChange={(event) => onEndDateChange(event.target.value)}
+              aria-label="End date"
+            />
+          </>
         ) : null}
-      </div>
-      <div className="card control-card">
-        <label htmlFor="metric-select">Metric</label>
+      </span>
+
+      <span className="header-control-group">
+        <label className="header-label" htmlFor="metric-select">Metrics</label>
         <select
           id="metric-select"
+          className="header-select"
           value={metric}
           onChange={(event) => onMetricChange(event.target.value)}
         >
@@ -91,12 +85,14 @@ export function FilterPanel({
           <option value="errors">Errors per day</option>
           <option value="utilization">Machine utilization</option>
         </select>
-      </div>
+      </span>
+
       {categoryOptions.length > 0 && metric !== 'errors' ? (
-        <div className="card control-card">
-          <label htmlFor="category-select">Category</label>
+        <span className="header-control-group">
+          <label className="header-label" htmlFor="category-select">Category</label>
           <select
             id="category-select"
+            className="header-select"
             value={categorySelection}
             onChange={(event) => onCategoryChange(event.target.value)}
           >
@@ -107,25 +103,24 @@ export function FilterPanel({
               </option>
             ))}
           </select>
-        </div>
+        </span>
       ) : null}
+
       {errorOptions.length > 0 && metric === 'errors' ? (
-        <div className="card control-card">
-          <label>Error types</label>
-          <div>
-            {errorOptions.map((error) => (
-              <label key={error} className="badge">
-                <input
-                  type="checkbox"
-                  checked={selectedErrors.size === 0 || selectedErrors.has(error)}
-                  onChange={() => onErrorToggle(error)}
-                />
-                <span>{error}</span>
-              </label>
-            ))}
-          </div>
-        </div>
+        <span className="header-control-group">
+          <span className="header-label">Error types</span>
+          {errorOptions.map((error) => (
+            <label key={error} className="badge">
+              <input
+                type="checkbox"
+                checked={selectedErrors.size === 0 || selectedErrors.has(error)}
+                onChange={() => onErrorToggle(error)}
+              />
+              <span>{error}</span>
+            </label>
+          ))}
+        </span>
       ) : null}
-    </section>
+    </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,6 @@ import { clearGuestMode, useAuth } from '@/lib/auth-context';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import {
   buildErrorCounts,
-  buildSummary,
   buildUtilization,
   filterByRange,
   formatDate,
@@ -34,6 +33,8 @@ const METRIC_FIELD: MetricToField = {
   operator: 'operator_id',
 };
 
+type SummaryFilter = 'pass' | 'fail' | 'boards' | null;
+
 export default function HomePage() {
   const router = useRouter();
   const { session, role, isGuest } = useAuth();
@@ -48,6 +49,7 @@ export default function HomePage() {
   const [page, setPage] = useState(1);
   const [categorySelection, setCategorySelection] = useState('top');
   const [selectedErrors, setSelectedErrors] = useState<Set<string>>(new Set());
+  const [summaryFilter, setSummaryFilter] = useState<SummaryFilter>(null);
 
   const loadData = useCallback(async (start: string, end: string) => {
     if (!start || !end) return;
@@ -83,6 +85,7 @@ export default function HomePage() {
       const e = formatDate(today);
       setStartDate(s);
       setEndDate(e);
+      setSummaryFilter(null);
       void loadData(s, e);
     }
   }, [rangePreset, loadData]);
@@ -107,6 +110,21 @@ export default function HomePage() {
     return filterByRange(records, activeRange.start, activeRange.end);
   }, [records, activeRange]);
 
+  const filteredRows = useMemo(() => {
+    if (!summaryFilter) return rowsInRange;
+    if (summaryFilter === 'pass') return rowsInRange.filter((r) => r.result === 'pass');
+    if (summaryFilter === 'fail') return rowsInRange.filter((r) => r.result === 'fail');
+    if (summaryFilter === 'boards') {
+      const seen = new Set<string>();
+      return rowsInRange.filter((r) => {
+        if (seen.has(r.serial_number)) return false;
+        seen.add(r.serial_number);
+        return true;
+      });
+    }
+    return rowsInRange;
+  }, [rowsInRange, summaryFilter]);
+
   const categoryOptions = useMemo(() => {
     if (!rowsInRange.length) return [];
     const field = METRIC_FIELD[metric];
@@ -124,30 +142,49 @@ export default function HomePage() {
     return buildUtilization(rowsInRange);
   }, [rowsInRange]);
 
-  const summaryItems = useMemo(() => {
-    if (!rowsInRange.length) return [];
-    if (metric === 'utilization' && utilizationData.length) {
-      const total = utilizationData.reduce((sum, u) => sum + u.count, 0);
-      const items = [
-        `Total tests: ${total}`,
-        `Active testers: ${utilizationData.length}`,
-      ];
-      utilizationData.slice(0, 5).forEach((u) => {
-        const pct = total > 0 ? Math.round((u.count / total) * 100) : 0;
-        items.push(`${u.tester}: ${u.count} boards (${pct}%, ~${u.perDay}/day)`);
+  // Summary stats (always based on full rowsInRange, not filteredRows)
+  const summaryStats = useMemo(() => {
+    if (!rowsInRange.length) return null;
+    const uniqueBoards = new Set(rowsInRange.map((r) => r.serial_number));
+    const passCount = rowsInRange.filter((r) => r.result === 'pass').length;
+    const failCount = rowsInRange.filter((r) => r.result === 'fail').length;
+
+    const errorCounts: Record<string, number> = {};
+    rowsInRange.forEach((r) => {
+      r.test_errors.forEach((e) => {
+        errorCounts[e.location] = (errorCounts[e.location] ?? 0) + 1;
       });
-      return items;
-    }
-    return buildSummary(rowsInRange);
-  }, [rowsInRange, metric, utilizationData]);
+    });
+    const topErrors = Object.entries(errorCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([loc, count]) => `${loc} (${count})`);
+
+    return { totalTests: rowsInRange.length, uniqueBoardCount: uniqueBoards.size, passCount, failCount, topErrors };
+  }, [rowsInRange]);
+
+  // Utilization summary items (for utilization metric)
+  const utilizationSummaryItems = useMemo(() => {
+    if (!utilizationData.length) return [];
+    const total = utilizationData.reduce((sum, u) => sum + u.count, 0);
+    const items = [
+      `Total tests: ${total}`,
+      `Active testers: ${utilizationData.length}`,
+    ];
+    utilizationData.slice(0, 5).forEach((u) => {
+      const pct = total > 0 ? Math.round((u.count / total) * 100) : 0;
+      items.push(`${u.tester}: ${u.count} boards (${pct}%, ~${u.perDay}/day)`);
+    });
+    return items;
+  }, [utilizationData]);
 
   const chartConfig = useMemo<ChartConfig>(() => {
-    if (!rowsInRange.length) return { labels: [], datasets: [], chartType: 'bar' };
+    if (!filteredRows.length) return { labels: [], datasets: [], chartType: 'bar' };
 
-    const labels = Array.from(groupByDate(rowsInRange).keys()).sort();
+    const labels = Array.from(groupByDate(filteredRows).keys()).sort();
 
     if (metric === 'boards') {
-      const counts = groupByDate(rowsInRange);
+      const counts = groupByDate(filteredRows);
       return {
         labels,
         datasets: [{ label: 'Boards tested', data: labels.map((l) => counts.get(l) ?? 0), backgroundColor: 'rgba(37, 99, 235, 0.7)' }],
@@ -181,7 +218,7 @@ export default function HomePage() {
 
     if (categorySelection !== 'top' && categoryOptions.includes(categorySelection)) {
       const data = labels.map((label) =>
-        rowsInRange.filter((r) => getDateKey(r) === label && r[field] === categorySelection).length
+        filteredRows.filter((r) => getDateKey(r) === label && r[field] === categorySelection).length
       );
       return {
         labels,
@@ -193,21 +230,21 @@ export default function HomePage() {
     const palette = ['#2563eb', '#10b981', '#f59e0b', '#ef4444', '#6366f1'];
     const datasets = categoryOptions.slice(0, 5).map((cat, idx) => ({
       label: cat,
-      data: labels.map((label) => rowsInRange.filter((r) => getDateKey(r) === label && r[field] === cat).length),
+      data: labels.map((label) => filteredRows.filter((r) => getDateKey(r) === label && r[field] === cat).length),
       backgroundColor: palette[idx % palette.length],
       stack: 'categories',
     }));
     return { labels, datasets, chartType: 'bar' };
-  }, [rowsInRange, metric, selectedErrors, errorInfo, categoryOptions, categorySelection, utilizationData]);
+  }, [filteredRows, metric, selectedErrors, errorInfo, categoryOptions, categorySelection, utilizationData]);
 
   const tableRows = useMemo(() => {
-    if (!rowsInRange.length) return [] as TestRecord[];
-    if (!selectedDate) return rowsInRange;
+    if (!filteredRows.length) return [] as TestRecord[];
+    if (!selectedDate) return filteredRows;
     if (metric === 'utilization') {
-      return rowsInRange.filter((r) => r.tester === selectedDate);
+      return filteredRows.filter((r) => r.tester === selectedDate);
     }
-    return rowsInRange.filter((r) => getDateKey(r) === selectedDate);
-  }, [rowsInRange, selectedDate, metric]);
+    return filteredRows.filter((r) => getDateKey(r) === selectedDate);
+  }, [filteredRows, selectedDate, metric]);
 
   const tableTitle = selectedDate
     ? metric === 'utilization'
@@ -223,21 +260,63 @@ export default function HomePage() {
   // TODO: implement AI chat feature here — replace the placeholder below.
   const showAiChat = !isGuest && role !== null && role !== 'ict-member';
 
+  function handleSummaryFilterToggle(filter: NonNullable<SummaryFilter>) {
+    setSummaryFilter((prev) => (prev === filter ? null : filter));
+    setSelectedDate(null);
+    setPage(1);
+  }
+
   return (
     <main>
       <header>
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           <h1>ICT Data Viewer</h1>
-          <p>Visualize ICT board test results from Supabase.</p>
           {isGuest && (
-            <p style={{ color: '#f59e0b', fontWeight: 'bold' }}>
-              Guest mode: Showing demo fixture data.{' '}
-              <a href="/login" style={{ color: '#f59e0b' }}>Sign in</a> for live data.
-            </p>
+            <span style={{ color: '#f59e0b', fontSize: '12px', fontWeight: 600 }}>
+              Guest mode —{' '}
+              <a href="/login" style={{ color: '#f59e0b' }}>Sign in</a>
+            </span>
           )}
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            className="btn-reload"
+            title="Reload data"
+            onClick={() => { void loadData(startDate, endDate); }}
+          >
+            ↻
+          </button>
+
+          <FilterPanel
+            onReload={() => void loadData(startDate, endDate)}
+            rangePreset={rangePreset}
+            onRangePresetChange={(value) => { setRangePreset(value); }}
+            startDate={startDate}
+            endDate={endDate}
+            onStartDateChange={(value) => { setStartDate(value); setRangePreset('custom'); }}
+            onEndDateChange={(value) => { setEndDate(value); setRangePreset('custom'); }}
+            metric={metric}
+            onMetricChange={(value) => {
+              setMetric(value);
+              setSelectedDate(null);
+              setCategorySelection('top');
+              setSelectedErrors(new Set());
+              setSummaryFilter(null);
+            }}
+            categoryOptions={categoryOptions}
+            categorySelection={categorySelection}
+            onCategoryChange={setCategorySelection}
+            errorOptions={errorInfo.errors}
+            selectedErrors={selectedErrors}
+            onErrorToggle={(value) => {
+              const next = new Set(selectedErrors);
+              if (next.has(value)) { next.delete(value); } else { next.add(value); }
+              setSelectedErrors(next);
+            }}
+          />
+
           {/* TODO: AI chat entry point — place chat button/panel here.
               Visible to ict-manager and ict-admin only (see showAiChat flag). */}
           {showAiChat && (
@@ -252,7 +331,7 @@ export default function HomePage() {
                 background: 'none',
                 border: '1px solid #e2e8f0',
                 borderRadius: '6px',
-                padding: '6px 12px',
+                padding: '5px 12px',
                 cursor: 'pointer',
                 fontSize: '13px',
                 color: '#4b5563',
@@ -263,33 +342,6 @@ export default function HomePage() {
           )}
         </div>
       </header>
-
-      <FilterPanel
-        onReload={() => void loadData(startDate, endDate)}
-        rangePreset={rangePreset}
-        onRangePresetChange={(value) => { setRangePreset(value); }}
-        startDate={startDate}
-        endDate={endDate}
-        onStartDateChange={(value) => { setStartDate(value); setRangePreset('custom'); }}
-        onEndDateChange={(value) => { setEndDate(value); setRangePreset('custom'); }}
-        metric={metric}
-        onMetricChange={(value) => {
-          setMetric(value);
-          setSelectedDate(null);
-          setCategorySelection('top');
-          setSelectedErrors(new Set());
-        }}
-        categoryOptions={categoryOptions}
-        categorySelection={categorySelection}
-        onCategoryChange={setCategorySelection}
-        errorOptions={errorInfo.errors}
-        selectedErrors={selectedErrors}
-        onErrorToggle={(value) => {
-          const next = new Set(selectedErrors);
-          if (next.has(value)) { next.delete(value); } else { next.add(value); }
-          setSelectedErrors(next);
-        }}
-      />
 
       <StatusBanner message={statusMessage} />
 
@@ -302,11 +354,59 @@ export default function HomePage() {
         />
         <div className="card">
           <h2>{metric === 'utilization' ? 'Utilization summary' : 'Range summary'}</h2>
-          <ul className="summary-list">
-            {summaryItems.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
+          {metric === 'utilization' ? (
+            <ul className="summary-list">
+              {utilizationSummaryItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : summaryStats ? (
+            <ul className="summary-list">
+              <li>
+                Total tests:{' '}
+                <button
+                  type="button"
+                  className={`summary-num${!summaryFilter ? ' summary-num--active' : ''}`}
+                  onClick={() => { setSummaryFilter(null); setSelectedDate(null); setPage(1); }}
+                >
+                  {summaryStats.totalTests}
+                </button>
+              </li>
+              <li>
+                Total # of boards:{' '}
+                <button
+                  type="button"
+                  className={`summary-num${summaryFilter === 'boards' ? ' summary-num--active' : ''}`}
+                  onClick={() => handleSummaryFilterToggle('boards')}
+                >
+                  {summaryStats.uniqueBoardCount}
+                </button>
+              </li>
+              <li>
+                Pass:{' '}
+                <button
+                  type="button"
+                  className={`summary-num${summaryFilter === 'pass' ? ' summary-num--active' : ''}`}
+                  onClick={() => handleSummaryFilterToggle('pass')}
+                >
+                  {summaryStats.passCount}
+                </button>
+                {' | '}
+                Fail:{' '}
+                <button
+                  type="button"
+                  className={`summary-num${summaryFilter === 'fail' ? ' summary-num--active' : ''}`}
+                  onClick={() => handleSummaryFilterToggle('fail')}
+                >
+                  {summaryStats.failCount}
+                </button>
+              </li>
+              <li>
+                Top errors:{' '}
+                {summaryStats.topErrors.length ? summaryStats.topErrors.join(', ') : 'None'}
+              </li>
+            </ul>
+          ) : null}
         </div>
       </section>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,19 +24,57 @@ header {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 24px 32px;
+  gap: 12px;
+  padding: 10px 24px;
   background: white;
   border-bottom: 1px solid #e2e8f0;
 }
 
 header h1 {
-  margin: 0 0 6px;
+  margin: 0;
+  font-size: 18px;
 }
 
 header p {
   margin: 0;
   color: #4b5563;
+}
+
+.btn-reload {
+  background: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+  color: #4b5563;
+}
+
+.btn-reload:hover {
+  background: #f1f5f9;
+}
+
+.header-control-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.header-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #4b5563;
+  white-space: nowrap;
+}
+
+.header-select {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid #cbd5e1;
+  font-size: 13px;
+  background: white;
+  color: #14213d;
 }
 
 .section {
@@ -118,6 +156,28 @@ header p {
   background: #f8fafc;
   padding: 12px;
   border-radius: 10px;
+}
+
+.summary-num {
+  background: none;
+  border: none;
+  font-weight: 700;
+  color: #2563eb;
+  cursor: pointer;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-size: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.summary-num:hover {
+  background: #eff6ff;
+}
+
+.summary-num--active {
+  background: #dbeafe;
+  color: #1d4ed8;
 }
 
 .table-wrapper {


### PR DESCRIPTION
## Summary
This PR refactors the dashboard header layout and adds interactive filtering capabilities to the summary statistics. The summary numbers (total tests, boards, pass/fail counts) are now clickable buttons that filter the displayed data, and the filter panel has been moved into the header for a more compact UI.

## Key Changes

- **Interactive Summary Filters**: Summary statistics (total tests, unique boards, pass/fail counts) are now clickable buttons that filter the chart and table data. Clicking a button toggles the filter on/off, allowing users to drill down into specific test results.

- **Header Layout Refactor**: 
  - Moved `FilterPanel` from a separate section into the header for better space utilization
  - Added a reload button (↻) in the header for quick data refresh
  - Converted filter controls to inline `header-control-group` layout with smaller, more compact styling
  - Reduced header padding and gap for a tighter, more modern appearance

- **Summary Statistics Restructuring**:
  - Removed `buildSummary` utility function import (no longer needed)
  - Created new `summaryStats` memoized value that calculates pass/fail counts, unique board count, and top errors
  - Split summary rendering into two paths: utilization metrics use `utilizationSummaryItems`, other metrics use interactive `summaryStats`
  - Added `SummaryFilter` type to manage filter state ('pass' | 'fail' | 'boards' | null)

- **Data Filtering Pipeline**:
  - Added `filteredRows` memoized value that applies the active summary filter to `rowsInRange`
  - Updated chart and table computations to use `filteredRows` instead of `rowsInRange`
  - Summary statistics remain based on full `rowsInRange` to show unfiltered counts

- **CSS Improvements**:
  - Added `.btn-reload`, `.header-control-group`, `.header-label`, `.header-select` styles for the new header layout
  - Added `.summary-num` and `.summary-num--active` styles for interactive summary buttons with hover and active states
  - Reduced header padding from 24px to 10px vertically for a more compact appearance

## Implementation Details

- The `summaryFilter` state is reset when changing date ranges or metrics to prevent stale filters
- The `handleSummaryFilterToggle` helper function manages toggling filters and resetting pagination/selected date
- Summary statistics are always calculated from the full range (not filtered data) to provide accurate context
- The filter panel's `onReload` prop was removed since the reload button is now in the header

https://claude.ai/code/session_01J3AbCysvPx2ycjn48tsaMN