### PR TITLE
Add expandable error lists and error filtering in summary

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 type FilterPanelProps = {
   onReload: () => void;
@@ -16,6 +16,7 @@ type FilterPanelProps = {
   errorOptions: string[];
   selectedErrors: Set<string>;
   onErrorToggle: (value: string) => void;
+  errorCounts?: Map<string, number>;
 };
 
 export function FilterPanel({
@@ -32,8 +33,10 @@ export function FilterPanel({
   onCategoryChange,
   errorOptions,
   selectedErrors,
-  onErrorToggle
+  onErrorToggle,
+  errorCounts = new Map(),
 }: FilterPanelProps) {
+  const [errorListExpanded, setErrorListExpanded] = useState(false);
   return (
     <>
       <span className="header-control-group">
@@ -108,17 +111,28 @@ export function FilterPanel({
 
       {errorOptions.length > 0 && metric === 'errors' ? (
         <span className="header-control-group">
-          <span className="header-label">Error types</span>
-          {errorOptions.map((error) => (
+          <span className="header-label">
+            Error types ({selectedErrors.size === 0 ? errorOptions.length : selectedErrors.size} of {errorOptions.length})
+          </span>
+          {(errorListExpanded ? errorOptions : errorOptions.slice(0, 5)).map((error) => (
             <label key={error} className="badge">
               <input
                 type="checkbox"
                 checked={selectedErrors.size === 0 || selectedErrors.has(error)}
                 onChange={() => onErrorToggle(error)}
               />
-              <span>{error}</span>
+              <span>{error} ({errorCounts.get(error) ?? 0})</span>
             </label>
           ))}
+          {errorOptions.length > 5 && (
+            <button
+              type="button"
+              onClick={() => setErrorListExpanded((v) => !v)}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 4px' }}
+            >
+              {errorListExpanded ? '▲ Show less' : `▼ +${errorOptions.length - 5} more`}
+            </button>
+          )}
         </span>
       ) : null}
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,6 +50,7 @@ export default function HomePage() {
   const [categorySelection, setCategorySelection] = useState('top');
   const [selectedErrors, setSelectedErrors] = useState<Set<string>>(new Set());
   const [summaryFilter, setSummaryFilter] = useState<SummaryFilter>(null);
+  const [summaryErrorsExpanded, setSummaryErrorsExpanded] = useState(false);
 
   const loadData = useCallback(async (start: string, end: string) => {
     if (!start || !end) return;
@@ -137,6 +138,16 @@ export default function HomePage() {
     return buildErrorCounts(rowsInRange);
   }, [rowsInRange]);
 
+  const errorTotals = useMemo(() => {
+    const m = new Map<string, number>();
+    filteredRows.forEach((r) => {
+      r.test_errors.forEach((e) => {
+        m.set(e.location, (m.get(e.location) ?? 0) + 1);
+      });
+    });
+    return m;
+  }, [filteredRows]);
+
   const utilizationData = useMemo<UtilizationEntry[]>(() => {
     if (!rowsInRange.length) return [];
     return buildUtilization(rowsInRange);
@@ -155,12 +166,10 @@ export default function HomePage() {
         errorCounts[e.location] = (errorCounts[e.location] ?? 0) + 1;
       });
     });
-    const topErrors = Object.entries(errorCounts)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5)
-      .map(([loc, count]) => `${loc} (${count})`);
+    const allErrorsSorted = Object.entries(errorCounts)
+      .sort((a, b) => b[1] - a[1]) as Array<[string, number]>;
 
-    return { totalTests: rowsInRange.length, uniqueBoardCount: uniqueBoards.size, passCount, failCount, topErrors };
+    return { totalTests: rowsInRange.length, uniqueBoardCount: uniqueBoards.size, passCount, failCount, allErrorsSorted };
   }, [rowsInRange]);
 
   // Utilization summary items (for utilization metric)
@@ -239,12 +248,20 @@ export default function HomePage() {
 
   const tableRows = useMemo(() => {
     if (!filteredRows.length) return [] as TestRecord[];
-    if (!selectedDate) return filteredRows;
-    if (metric === 'utilization') {
-      return filteredRows.filter((r) => r.tester === selectedDate);
+
+    let rows = filteredRows;
+    if (metric === 'errors' && selectedErrors.size > 0) {
+      rows = rows.filter((r) =>
+        r.test_errors.some((e) => selectedErrors.has(e.location))
+      );
     }
-    return filteredRows.filter((r) => getDateKey(r) === selectedDate);
-  }, [filteredRows, selectedDate, metric]);
+
+    if (!selectedDate) return rows;
+    if (metric === 'utilization') {
+      return rows.filter((r) => r.tester === selectedDate);
+    }
+    return rows.filter((r) => getDateKey(r) === selectedDate);
+  }, [filteredRows, selectedDate, metric, selectedErrors]);
 
   const tableTitle = selectedDate
     ? metric === 'utilization'
@@ -262,6 +279,14 @@ export default function HomePage() {
 
   function handleSummaryFilterToggle(filter: NonNullable<SummaryFilter>) {
     setSummaryFilter((prev) => (prev === filter ? null : filter));
+    setSelectedDate(null);
+    setPage(1);
+  }
+
+  function handleSummaryErrorClick(errorLocation: string) {
+    setMetric('errors');
+    setSelectedErrors(new Set([errorLocation]));
+    setSummaryFilter(null);
     setSelectedDate(null);
     setPage(1);
   }
@@ -309,6 +334,7 @@ export default function HomePage() {
             categorySelection={categorySelection}
             onCategoryChange={setCategorySelection}
             errorOptions={errorInfo.errors}
+            errorCounts={errorTotals}
             selectedErrors={selectedErrors}
             onErrorToggle={(value) => {
               const next = new Set(selectedErrors);
@@ -402,8 +428,39 @@ export default function HomePage() {
                 </button>
               </li>
               <li>
-                Top errors:{' '}
-                {summaryStats.topErrors.length ? summaryStats.topErrors.join(', ') : 'None'}
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span>Top errors</span>
+                  {summaryStats.allErrorsSorted.length > 5 && (
+                    <button
+                      type="button"
+                      className="summary-num"
+                      onClick={() => setSummaryErrorsExpanded((v) => !v)}
+                    >
+                      {summaryErrorsExpanded ? '▲' : `▼ ${summaryStats.allErrorsSorted.length}`}
+                    </button>
+                  )}
+                </div>
+                {summaryStats.allErrorsSorted.length === 0 ? (
+                  <span style={{ color: '#6b7280', fontSize: '13px' }}>None</span>
+                ) : (
+                  <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0', display: 'grid', gap: '4px' }}>
+                    {(summaryErrorsExpanded
+                      ? summaryStats.allErrorsSorted
+                      : summaryStats.allErrorsSorted.slice(0, 5)
+                    ).map(([loc, count]) => (
+                      <li key={loc} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px' }}>
+                        <span>{loc}</span>
+                        <button
+                          type="button"
+                          className="summary-num"
+                          onClick={() => handleSummaryErrorClick(loc)}
+                        >
+                          {count}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </li>
             </ul>
           ) : null}


### PR DESCRIPTION
## Summary
Enhanced the error display and filtering functionality by making error lists expandable and adding the ability to filter test records by clicking on errors in the summary section.

## Key Changes
- **Expandable error lists**: Both the summary "Top errors" section and the filter panel "Error types" now show only the first 5 items by default with an expand/collapse button to view all errors
- **Error filtering from summary**: Added `handleSummaryErrorClick()` to allow users to click on error counts in the summary to filter the table to show only tests with that specific error
- **Error count tracking**: Added `errorTotals` memo to calculate error occurrence counts across filtered rows, displayed next to each error in the filter panel
- **Enhanced filter panel**: Updated to show error counts and display selected/total error counts in the header
- **Improved table filtering**: Modified `tableRows` memo to filter by selected errors when in 'errors' metric mode
- **State management**: Added `summaryErrorsExpanded` state to track expansion state of summary errors list and `errorListExpanded` state in FilterPanel

## Implementation Details
- Error counts are now calculated from `filteredRows` rather than just the date range, providing more contextual information
- The summary now displays `allErrorsSorted` (all errors sorted by count) instead of just the top 5, enabling the expand functionality
- Error filtering is applied before date/tester filtering in the table rows logic
- Styling uses inline styles for the expandable sections with consistent visual indicators (▲/▼ arrows)

https://claude.ai/code/session_01QMXfFisVUnrfJkMWGRhWsh