### PR TITLE
Implement pagination for Supabase test records query

### DIFF
--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -48,6 +48,7 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
       .gte('start_time', start)
       .lte('start_time', end + 'T23:59:59Z')
       .order('start_time', { ascending: false })
+      .order('id', { ascending: false })
       .range(from, from + BATCH - 1);
 
     if (error) throw new Error(`Supabase query failed: ${error.message}`);

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -30,22 +30,35 @@ function getSupabaseForUser(authHeader: string): SupabaseClient {
 }
 
 async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string): Promise<TestRecord[]> {
-  const { data, error } = await sb
-    .from('tests')
-    .select(`
-      *,
-      boards!inner (serial_number, mac_address, rev, product_id,
-        products!inner (product_name, part_number)),
-      test_errors (error_type, location, subtest, part_spec, unit, measured_raw, nominal_raw, high_limit_raw, low_limit_raw, threshold_raw)
-    `)
-    .gte('start_time', start)
-    .lte('start_time', end + 'T23:59:59Z')
-    .order('start_time', { ascending: false })
-    .limit(5000);
+  // Supabase PostgREST caps responses at max_rows (default 1000) per request.
+  // Use .range() in a loop to paginate past that limit and retrieve all records.
+  const BATCH = 1000;
+  const allRows: any[] = [];
+  let from = 0;
 
-  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+  while (true) {
+    const { data, error } = await sb
+      .from('tests')
+      .select(`
+        *,
+        boards!inner (serial_number, mac_address, rev, product_id,
+          products!inner (product_name, part_number)),
+        test_errors (error_type, location, subtest, part_spec, unit, measured_raw, nominal_raw, high_limit_raw, low_limit_raw, threshold_raw)
+      `)
+      .gte('start_time', start)
+      .lte('start_time', end + 'T23:59:59Z')
+      .order('start_time', { ascending: false })
+      .range(from, from + BATCH - 1);
 
-  return (data ?? []).map((row: any): TestRecord => ({
+    if (error) throw new Error(`Supabase query failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+
+    allRows.push(...data);
+    if (data.length < BATCH) break; // last page reached
+    from += BATCH;
+  }
+
+  return allRows.map((row: any): TestRecord => ({
     id:           row.id,
     board_id:     row.board_id,
     start_time:   row.start_time,


### PR DESCRIPTION
## Summary
Modified the `fetchFromSupabase` function to implement pagination when querying test records from Supabase, allowing retrieval of more than the default 1000 row limit per request.

## Key Changes
- Replaced single `.limit(5000)` query with a paginated loop using `.range()` to fetch records in 1000-row batches
- Added logic to accumulate results across multiple requests until all matching records are retrieved
- Removed the hardcoded limit and now fetches all available records within the date range
- Added early termination when a batch returns fewer records than the batch size, indicating the last page

## Implementation Details
- Uses a `BATCH` constant set to 1000 (Supabase PostgREST default max_rows)
- Implements a while loop that increments the `from` offset by `BATCH` size after each successful request
- Breaks pagination when either no data is returned or when a partial batch is received
- Maintains the same query structure and result mapping as the original implementation

https://claude.ai/code/session_01V4rG2L58FJJVLbtBzJA7ch