### PR TITLE
Add threshold_value parsing and fix Subtest block scanning

### DIFF
--- a/src/__tests__/ict-parser.test.ts
+++ b/src/__tests__/ict-parser.test.ts
@@ -388,6 +388,140 @@ describe('parseLog — threshold-style (jumper resistance) error blocks (Bug 2)'
 });
 
 // ---------------------------------------------------------------------------
+// parseLog — B1 fix: threshold_value float field and Subtest: branch scan fix
+// ---------------------------------------------------------------------------
+
+// Threshold-only Subtest: block — no Measured: line.
+// Previously "Threshold: 18.000" would land verbatim in measured_raw (position-based parsing bug).
+const LOG_SUBTEST_THRESHOLD_ONLY = `----------------------------------------
+TestPlan-A-v4.1
+Mon Mar 16 10:00:00 2026
+----------------------------------------
+jp_chk HAS FAILED
+Subtest: Loopback Check
+Threshold: 18.000
+Jumper Resistance in OHMS
+----------------------------------------
+Board #: 0
+Version:
+S/N:PROD-999+SN-XXXX-000099
+&v2S Family: Test Product X
+&v2S ############################
+&v2S #### BOARD ICT FAIL  #####
+&v2S ############################
+&v2S ST:260316100000
+&v2S ET:260316100130
+&v2S SN:PROD-999+SN-XXXX-000099
+&v2S P/N:PART-REDACTED-001 Rev:1
+&v3S Mac:020000000099
+&v2S OPERATOR ID:operator-99
+&v3S Fixture_ID: fixture-01
+&v2S TESTER:tester-01
+`;
+
+// Subtest: block with both Measured: and Threshold: — regression guard.
+const LOG_SUBTEST_WITH_MEASURED = `----------------------------------------
+TestPlan-A-v4.1
+Mon Mar 16 10:00:00 2026
+----------------------------------------
+jp_chk2 HAS FAILED
+Subtest: Full Check
+Measured:   5.500
+Threshold: 10.000
+Jumper Resistance in OHMS
+----------------------------------------
+Board #: 0
+Version:
+S/N:PROD-999+SN-XXXX-000099
+&v2S Family: Test Product X
+&v2S ############################
+&v2S #### BOARD ICT FAIL  #####
+&v2S ############################
+&v2S ST:260316100000
+&v2S ET:260316100130
+&v2S SN:PROD-999+SN-XXXX-000099
+&v2S P/N:PART-REDACTED-001 Rev:1
+&v3S Mac:020000000099
+&v2S OPERATOR ID:operator-99
+&v3S Fixture_ID: fixture-01
+&v2S TESTER:tester-01
+`;
+
+describe('parseLog — B1: threshold_value + Subtest: scan fix', () => {
+  it('Subtest-only-threshold: threshold_raw is the bare value, not "Threshold: ..."', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_THRESHOLD_ONLY);
+    const err = r.errors.find((e) => e.location === 'jp_chk')!;
+    expect(err).toBeDefined();
+    expect(err.threshold_raw).toBe('18.000');
+    expect(err.threshold_raw).not.toMatch(/Threshold/i);
+  });
+
+  it('Subtest-only-threshold: measured_raw does not contain "Threshold:"', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_THRESHOLD_ONLY);
+    const err = r.errors.find((e) => e.location === 'jp_chk')!;
+    expect(err.measured_raw).not.toMatch(/Threshold/i);
+  });
+
+  it('Subtest-only-threshold: threshold_value is the correct float', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_THRESHOLD_ONLY);
+    const err = r.errors.find((e) => e.location === 'jp_chk')!;
+    expect(err.threshold_value).toBeCloseTo(18.0);
+  });
+
+  it('Subtest-only-threshold: subtest is extracted', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_THRESHOLD_ONLY);
+    const err = r.errors.find((e) => e.location === 'jp_chk')!;
+    expect(err.subtest).toBe('Loopback Check');
+  });
+
+  it('Subtest-only-threshold: error_type is shorts_report', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_THRESHOLD_ONLY);
+    const err = r.errors.find((e) => e.location === 'jp_chk')!;
+    expect(err.error_type).toBe('shorts_report');
+  });
+
+  it('Subtest-with-measured: measured_raw and threshold_raw both correct (regression)', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_SUBTEST_WITH_MEASURED);
+    const err = r.errors.find((e) => e.location === 'jp_chk2')!;
+    expect(err.measured_raw).toBe('5.500');
+    expect(err.threshold_raw).toBe('10.000');
+    expect(err.threshold_value).toBeCloseTo(10.0);
+    expect(err.subtest).toBe('Full Check');
+  });
+
+  it('threshold_value from LOG_THRESHOLD_COMMON is 10.0', () => {
+    const r = parseLog('PROD-999_SN-XXXX-000099.log', LOG_THRESHOLD_COMMON);
+    const err = r.errors.find((e) => e.location === 'jp_loopback')!;
+    expect(err.threshold_value).toBeCloseTo(10.0);
+  });
+
+  it('threshold_value from unit-suffixed raw (k suffix → *1000)', () => {
+    const r = parseLog('PROD-001_SN-XXXX-000003.log', log000003);
+    const shorts = r.errors.find((e) => e.location === 'pwr_res_chk')!;
+    // threshold_raw is truthy per existing test; threshold_value should be a number
+    expect(typeof shorts.threshold_value).toBe('number');
+    expect(shorts.threshold_value).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseUnitValue — unit suffix conversion
+// ---------------------------------------------------------------------------
+import { parseUnitValue } from '@/lib/ict-parser';
+
+describe('parseUnitValue', () => {
+  it('returns null for null input', () => expect(parseUnitValue(null)).toBeNull());
+  it('returns null for empty string', () => expect(parseUnitValue('')).toBeNull());
+  it('parses plain float', () => expect(parseUnitValue('17.500')).toBeCloseTo(17.5));
+  it('parses u suffix (micro)', () => expect(parseUnitValue('0.78327u')).toBeCloseTo(0.78327e-6));
+  it('parses p suffix (pico)', () => expect(parseUnitValue('233.26p')).toBeCloseTo(233.26e-12));
+  it('parses k suffix (kilo)', () => expect(parseUnitValue('20.000k')).toBeCloseTo(20000));
+  it('parses M suffix (mega)', () => expect(parseUnitValue('1.5612M')).toBeCloseTo(1561200));
+  it('parses m suffix (milli)', () => expect(parseUnitValue('5.000m')).toBeCloseTo(0.005));
+  it('parses n suffix (nano)', () => expect(parseUnitValue('10.000n')).toBeCloseTo(10e-9));
+});
+
+// ---------------------------------------------------------------------------
 // parseLog — raw_block capture (Enhancement)
 // ---------------------------------------------------------------------------
 describe('parseLog — raw_block capture', () => {

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -110,7 +110,7 @@ export function FilterPanel({
       ) : null}
 
       {errorOptions.length > 0 && metric === 'errors' ? (
-        <span className="header-control-group">
+        <span className="header-control-group header-control-group--wrap">
           <span className="header-label">
             Error types ({selectedErrors.size === 0 ? errorOptions.length : selectedErrors.size} of {errorOptions.length})
           </span>

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -109,8 +109,9 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
       nominal_raw:    e.nominal_raw,
       high_limit_raw: e.high_limit_raw,
       low_limit_raw:  e.low_limit_raw,
-      threshold_raw:  e.threshold_raw,
-      raw_block:      e.raw_block,
+      threshold_raw:   e.threshold_raw,
+      threshold_value: e.threshold_value,
+      raw_block:       e.raw_block,
     }))
   );
   if (errErr) throw new Error(`test_errors insert failed: ${errErr.message}`);

--- a/src/lib/ict-parser.ts
+++ b/src/lib/ict-parser.ts
@@ -24,17 +24,18 @@ export interface ParsedTest {
 }
 
 export interface ParsedError {
-  error_type:     'analog' | 'digital_pin' | 'shorts_report' | 'unknown';
-  location:       string;       // PCB component reference (was: component)
-  subtest:        string | null;
-  part_spec:      string;       // component value, e.g. "1UF" (was: component_value)
-  unit:           string;       // "FARADS" | "OHMS" | ""
-  measured_raw:   string;
-  nominal_raw:    string;
-  high_limit_raw: string;
-  low_limit_raw:  string;
-  threshold_raw:  string | null;
-  raw_block:      string | null; // raw lines that produced this error; null if not captured
+  error_type:      'analog' | 'digital_pin' | 'shorts_report' | 'unknown';
+  location:        string;       // PCB component reference (was: component)
+  subtest:         string | null;
+  part_spec:       string;       // component value, e.g. "1UF" (was: component_value)
+  unit:            string;       // "FARADS" | "OHMS" | ""
+  measured_raw:    string;
+  nominal_raw:     string;
+  high_limit_raw:  string;
+  low_limit_raw:   string;
+  threshold_raw:   string | null;
+  threshold_value: number | null; // threshold_raw parsed to base-unit float
+  raw_block:       string | null; // raw lines that produced this error; null if not captured
 }
 
 const SEPARATOR = '----------------------------------------';
@@ -51,6 +52,23 @@ export function parseTimestamp(ts: string): Date {
   const min = parseInt(s.slice(8, 10), 10);
   const sec = parseInt(s.slice(10, 12), 10);
   return new Date(Date.UTC(year, month, day, hour, min, sec));
+}
+
+/**
+ * Convert a raw ICT value string with an optional SI suffix to a base-unit float.
+ * Suffixes: p=1e-12, n=1e-9, u=1e-6, m=1e-3, k=1e3, M=1e6, G=1e9
+ * Returns null when the input is null/empty or cannot be parsed.
+ */
+export function parseUnitValue(raw: string | null): number | null {
+  if (!raw) return null;
+  const m = raw.trim().match(/^([+-]?\d+(?:\.\d+)?)([pnumkMG]?)$/);
+  if (!m) return null;
+  const num = parseFloat(m[1]);
+  const suffixMap: Record<string, number> = {
+    p: 1e-12, n: 1e-9, u: 1e-6, m: 1e-3, k: 1e3, M: 1e6, G: 1e9,
+  };
+  const scale = m[2] ? (suffixMap[m[2]] ?? 1) : 1;
+  return num * scale;
 }
 
 /**
@@ -187,25 +205,24 @@ export function parseLog(filename: string, content: string): ParsedTest {
           j++;
         }
       } else if (/^Subtest:/i.test(defLine)) {
-        // Resistance/shorts check with subtest
+        // Resistance/shorts check with subtest.
+        // Content-based scan handles blocks that have Measured: and/or Threshold: in any order,
+        // and correctly handles blocks where Measured: is absent (threshold-only variant).
         error_type = 'shorts_report';
         subtest = defLine.replace(/^Subtest:\s*/i, '').trim();
         j++;
-        // measured_raw
-        const measLine = (lines[j] ?? '').trimEnd();
-        measured_raw = measLine.replace(/^Measured:\s*/i, '').trim();
-        j++;
-        // threshold_raw
-        const threshLine = (lines[j] ?? '').trimEnd();
-        if (/^Threshold:/i.test(threshLine)) {
-          threshold_raw = threshLine.replace(/^Threshold:\s*/i, '').trim();
+        while (j < lines.length) {
+          const scanLine = (lines[j] ?? '').trimEnd();
+          if (scanLine === SEPARATOR || /\bHAS FAILED\b/i.test(scanLine)) break;
+          if (/^Measured:\s*/i.test(scanLine)) {
+            measured_raw = scanLine.replace(/^Measured:\s*/i, '').trim();
+          } else if (/^Threshold:\s*/i.test(scanLine)) {
+            threshold_raw = scanLine.replace(/^Threshold:\s*/i, '').trim();
+          }
+          const unitMatch = scanLine.match(/\bin\s+(FARADS|OHMS)\b/i);
+          if (unitMatch) unit = unitMatch[1].toUpperCase();
           j++;
         }
-        // unit line: "Jumper Resistance in OHMS" etc.
-        const unitLine = (lines[j] ?? '').trimEnd();
-        const unitMatch = unitLine.match(/\bin\s+(FARADS|OHMS)\b/i);
-        unit = unitMatch ? unitMatch[1].toUpperCase() : '';
-        j++;
       } else {
         // Standard analog or threshold-style (jumper resistance) failure.
         // Try to extract COMP=value from the definition line first.
@@ -245,6 +262,8 @@ export function parseLog(filename: string, content: string): ParsedTest {
       // Capture the raw lines that produced this error record (from HAS FAILED up to j).
       const raw_block = lines.slice(blockStart, j).join('\n');
 
+      const threshold_value = parseUnitValue(threshold_raw);
+
       // Deduplicate by location (keep first occurrence)
       if (!errorMap.has(location)) {
         errorMap.set(location, {
@@ -258,6 +277,7 @@ export function parseLog(filename: string, content: string): ParsedTest {
           high_limit_raw,
           low_limit_raw,
           threshold_raw,
+          threshold_value,
           raw_block,
         });
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -430,7 +430,7 @@ export default function HomePage() {
               <li>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span>Top errors</span>
-                  {summaryStats.allErrorsSorted.length > 5 && (
+                  {summaryStats.allErrorsSorted.length > 3 && (
                     <button
                       type="button"
                       className="summary-num"
@@ -446,7 +446,7 @@ export default function HomePage() {
                   <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0', display: 'grid', gap: '4px' }}>
                     {(summaryErrorsExpanded
                       ? summaryStats.allErrorsSorted
-                      : summaryStats.allErrorsSorted.slice(0, 5)
+                      : summaryStats.allErrorsSorted.slice(0, 3)
                     ).map(([loc, count]) => (
                       <li key={loc} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px' }}>
                         <span>{loc}</span>

--- a/src/pipeline/docs/schema.sql
+++ b/src/pipeline/docs/schema.sql
@@ -99,8 +99,9 @@ ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS measured_raw   text;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS nominal_raw    text;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS high_limit_raw text;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS low_limit_raw  text;
-ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS threshold_raw  text;
-ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS raw_block      text;
+ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS threshold_raw   text;
+ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS threshold_value float8;
+ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS raw_block       text;
 
 -- ============================================================
 -- 5. Rolling 3-month delete  (pg_cron)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -61,6 +61,11 @@ header p {
   gap: 6px;
 }
 
+.header-control-group--wrap {
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
 .header-label {
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
This PR adds support for parsing threshold values with SI unit suffixes (p, n, u, m, k, M, G) and fixes a bug in the Subtest block scanner that incorrectly captured threshold lines as measured values.

## Key Changes

- **New `parseUnitValue()` function**: Converts raw ICT value strings with optional SI suffixes to base-unit floats. Handles suffixes: p (pico), n (nano), u (micro), m (milli), k (kilo), M (mega), G (giga).

- **Fixed Subtest block scanning**: Replaced position-based parsing with content-based scanning that:
  - Correctly handles threshold-only blocks (no Measured: line)
  - Properly extracts both Measured: and Threshold: values regardless of order
  - Prevents threshold lines from being incorrectly captured as measured values

- **Added `threshold_value` field**: New nullable float field in `ParsedError` interface that stores the parsed threshold value in base units.

- **Database schema update**: Added `threshold_value float8` column to `test_errors` table.

- **Comprehensive test coverage**: Added 10 new test cases covering:
  - Threshold-only Subtest blocks
  - Subtest blocks with both Measured and Threshold values
  - Unit suffix parsing (p, n, u, m, k, M)
  - Regression guards for existing functionality

- **Minor UI improvements**: 
  - Added `.header-control-group--wrap` CSS class for flexible control group layout
  - Adjusted "Top errors" expansion threshold from 5 to 3 items

## Implementation Details

The Subtest block scanner now uses a while loop that scans lines until it encounters a separator or "HAS FAILED" marker, extracting Measured and Threshold values via regex matching. This approach is more robust than the previous fixed-position parsing and handles edge cases where lines may be missing or reordered.

https://claude.ai/code/session_01PEfe9Zvp7EmcGgERb34WrE