### PR TITLE
Improve data refresh UX with timeout handling and stale data preservation

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,7 +21,7 @@
 
 ## 🐛 Bugs
 
-### B2 — Query timeout / data refresh UX
+### ✅ B2 — Query timeout / data refresh UX
 **Problem:** The frontend occasionally shows a query timeout error, likely correlated with large data imports running concurrently. Additionally, when a data refresh fails, the UI flushes existing data — leaving the user with an empty view instead of stale-but-usable data.
 
 **Required behavior:**
@@ -32,6 +32,14 @@
 
 **Effort:** Medium
 **Notes:** Investigate whether Supabase query timeouts can be tuned (statement_timeout). Also check if the hourly ingest job causes DB load spikes that overlap with frontend queries.
+
+**Done (2026-03-17):**
+- Removed `setRecords([])` from `loadData` error handler — stale data preserved on refresh failure
+- Added `hasDataRef` to distinguish "initial load error" (show raw error) from "refresh failure" (show "Last refresh failed — showing previous data")
+- Added `AbortController` + `QUERY_TIMEOUT_MS = 15_000` constant — queries now fail fast after 15s instead of hanging on browser default (~2 min)
+- `finally` block clears the abort timer in all code paths
+- Fixed `GET /api/tests`: raised `BATCH` from 1000 → 5000 (matching Supabase `max_rows` config); replaced `SELECT *` with explicit column list
+- No polling found during audit; no overly aggressive refetch triggers
 
 ---
 

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import HomePage from '@/pages/index';
 import type { TestRecord } from '@/lib/testUtils';
 
@@ -67,8 +67,7 @@ const MOCK_RECORD: TestRecord = {
 
 beforeEach(() => {
   mockUseAuth.mockReturnValue({
-    session:   { access_token: 'test-jwt' },
-    user:      { id: 'user-1' },
+    session:   { access_token: 'test-jwt', user: { id: 'user-1' } },
     role:      'ict-manager',
     isGuest:   false,
     isLoading: false,
@@ -285,6 +284,49 @@ describe('HomePage', () => {
       await waitFor(() => {
         expect(screen.getByText(/timed out/i)).toBeInTheDocument();
       });
+    });
+
+    it('clears stale authenticated data when the session signs out', async () => {
+      const { rerender } = render(<HomePage />);
+
+      // Wait for initial successful load — record should be visible.
+      await waitFor(() => {
+        const items = screen.getAllByRole('listitem');
+        expect(items.some((el) => /Total tests: 1/i.test(el.textContent ?? ''))).toBe(true);
+      });
+
+      // Simulate sign-out: session becomes null; API now returns 401 (realistic — the
+      // server rejects unauthenticated requests).  This also exercises the path where
+      // hasDataRef has been reset to false, so the error message is the raw error (not
+      // the "showing previous data" stale-data message).
+      mockUseAuth.mockReturnValue({
+        session:   null,
+        role:      null,
+        isGuest:   false,
+        isLoading: false,
+      });
+      (global.fetch as jest.Mock).mockImplementation((url: string) => {
+        if ((url as string).includes('/api/tests')) {
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'Unauthorized' }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({ products: [] }) });
+      });
+
+      // Re-render triggers the identity-change useEffect (records cleared, hasDataRef reset)
+      // and the rangePreset effect (new loadData due to session change → fetch fails → raw error,
+      // NOT the "showing previous data" banner, because hasDataRef was already reset).
+      await act(async () => {
+        rerender(<HomePage />);
+      });
+
+      // No stale records should remain in the DOM after the sign-out.
+      await waitFor(() => {
+        const items = screen.queryAllByRole('listitem');
+        expect(items.some((el) => /Total tests: 1/i.test(el.textContent ?? ''))).toBe(false);
+      });
+
+      // Stale-data banner must NOT be shown (hasDataRef was reset before the failed fetch).
+      expect(screen.queryByText(/showing previous data/i)).toBeNull();
     });
   });
 });

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -214,4 +214,77 @@ describe('HomePage', () => {
     fireEvent.change(productSelect, { target: { value: 'Test Product A' } });
     expect(productSelect.value).toBe('Test Product A');
   });
+
+  describe('error and timeout behaviour', () => {
+    it('keeps existing records when a subsequent fetch fails', async () => {
+      // First fetch succeeds — loads one record.
+      render(<HomePage />);
+      await waitFor(() => {
+        const items = screen.getAllByRole('listitem');
+        expect(items.some((el) => /Total tests: 1/i.test(el.textContent ?? ''))).toBe(true);
+      });
+
+      // Second fetch (reload) fails — records must stay visible.
+      (global.fetch as jest.Mock).mockImplementationOnce((url: string) => {
+        if ((url as string).includes('/api/tests')) {
+          return Promise.resolve({
+            ok: false,
+            json: async () => ({ error: 'DB unavailable' }),
+          });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({ products: [] }) });
+      });
+
+      const reloadBtn = screen.getByTitle('Reload data');
+      fireEvent.click(reloadBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Last refresh failed/i)).toBeInTheDocument();
+      });
+
+      // Record from the first successful load must still render.
+      const items = screen.getAllByRole('listitem');
+      expect(items.some((el) => /Total tests: 1/i.test(el.textContent ?? ''))).toBe(true);
+    });
+
+    it('shows error banner (not full-page error) when refresh fails with stale data', async () => {
+      render(<HomePage />);
+      await waitFor(() => screen.getAllByRole('listitem'));
+
+      (global.fetch as jest.Mock).mockImplementationOnce((url: string) => {
+        if ((url as string).includes('/api/tests')) {
+          return Promise.resolve({ ok: false, json: async () => ({ error: 'timeout' }) });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({ products: [] }) });
+      });
+
+      fireEvent.click(screen.getByTitle('Reload data'));
+
+      await waitFor(() => {
+        const banner = screen.getByText(/Last refresh failed/i);
+        // Banner must be in a section (non-modal, non-full-page element).
+        expect(banner.closest('section')).not.toBeNull();
+      });
+    });
+
+    it('shows timeout message when fetch is aborted', async () => {
+      render(<HomePage />);
+      await waitFor(() => screen.getAllByRole('listitem'));
+
+      (global.fetch as jest.Mock).mockImplementationOnce((url: string) => {
+        if ((url as string).includes('/api/tests')) {
+          return Promise.reject(
+            Object.assign(new DOMException('The user aborted a request.', 'AbortError'), {}),
+          );
+        }
+        return Promise.resolve({ ok: true, json: async () => ({ products: [] }) });
+      });
+
+      fireEvent.click(screen.getByTitle('Reload data'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/timed out/i)).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -30,9 +30,10 @@ function getSupabaseForUser(authHeader: string): SupabaseClient {
 }
 
 async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string): Promise<TestRecord[]> {
-  // Supabase PostgREST caps responses at max_rows (default 1000) per request.
-  // Use .range() in a loop to paginate past that limit and retrieve all records.
-  const BATCH = 1000;
+  // Supabase project has max_rows set to 5000. Paginate in batches of 5000 so
+  // the common case (≤5000 rows) is a single round trip; larger ranges still
+  // paginate correctly.
+  const BATCH = 5000;
   const allRows: any[] = [];
   let from = 0;
 
@@ -40,7 +41,7 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
     const { data, error } = await sb
       .from('tests')
       .select(`
-        *,
+        id, board_id, start_time, end_time, result, operator_id, fixture_id, tester, source_file, ingested_at,
         boards!inner (serial_number, mac_address, rev, product_id,
           products!inner (product_name, part_number)),
         test_errors (error_type, location, subtest, part_spec, unit, measured_raw, nominal_raw, high_limit_raw, low_limit_raw, threshold_raw)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,6 +35,9 @@ const METRIC_FIELD: MetricToField = {
 
 type SummaryFilter = 'pass' | 'fail' | 'boards' | null;
 
+/** Cap frontend queries at this duration; tune here if needed. */
+const QUERY_TIMEOUT_MS = 15_000;
+
 export default function HomePage() {
   const router = useRouter();
   const { session, role, isGuest } = useAuth();
@@ -61,19 +64,25 @@ export default function HomePage() {
   // stale responses (e.g. the default 30-day load racing the URL-seeded load) are
   // discarded before they can overwrite the result of the most recent request.
   const loadIdRef = useRef(0);
+  // True once the first successful fetch has resolved; used to pick the right
+  // error message (stale-data fallback vs. hard initial-load failure).
+  const hasDataRef = useRef(false);
 
   const loadData = useCallback(async (start: string, end: string) => {
     if (!start || !end) return;
     const myId = ++loadIdRef.current;
-    try {
-      setStatus('Loading data...');
+    setStatus('Loading data...');
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), QUERY_TIMEOUT_MS);
+
+    try {
       const headers: Record<string, string> = {};
       if (session?.access_token) {
         headers['Authorization'] = `Bearer ${session.access_token}`;
       }
 
-      const res = await fetch(`/api/tests?start=${start}&end=${end}`, { headers });
+      const res = await fetch(`/api/tests?start=${start}&end=${end}`, { headers, signal: controller.signal });
       if (!res.ok) {
         const body = (await res.json()) as { error?: string };
         throw new Error(body.error ?? `HTTP ${res.status}`);
@@ -81,11 +90,18 @@ export default function HomePage() {
       const body = (await res.json()) as { records: TestRecord[]; demo: boolean };
       if (myId !== loadIdRef.current) return;
       setRecords(body.records);
+      hasDataRef.current = true;
       setStatus(null);
     } catch (err) {
       if (myId !== loadIdRef.current) return;
-      setStatus(err instanceof Error ? err.message : 'Unable to load data.');
-      setRecords([]);
+      const isTimeout = err instanceof DOMException && err.name === 'AbortError';
+      const rawMsg = isTimeout
+        ? `Request timed out after ${QUERY_TIMEOUT_MS / 1000}s`
+        : (err instanceof Error ? err.message : 'Unable to load data.');
+      // Keep stale records visible — only update the status message.
+      setStatus(hasDataRef.current ? `Last refresh failed — showing previous data (${rawMsg})` : rawMsg);
+    } finally {
+      clearTimeout(timeoutId);
     }
   }, [session]);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -67,6 +67,21 @@ export default function HomePage() {
   // True once the first successful fetch has resolved; used to pick the right
   // error message (stale-data fallback vs. hard initial-load failure).
   const hasDataRef = useRef(false);
+  // Tracks the user ID from the previous render. Starts as `undefined` (sentinel
+  // meaning "no prior identity seen") so the initial mount never triggers a clear.
+  const prevUserIdRef = useRef<string | undefined>(undefined);
+
+  // When the authenticated user identity changes (sign-out, session expiry, or a
+  // different user logging in), discard any stale private data immediately so it
+  // cannot be rendered in the new/unauthenticated context.
+  useEffect(() => {
+    const currentUserId = session?.user?.id;
+    if (prevUserIdRef.current !== undefined && prevUserIdRef.current !== currentUserId) {
+      setRecords([]);
+      hasDataRef.current = false;
+    }
+    prevUserIdRef.current = currentUserId;
+  }, [session]);
 
   const loadData = useCallback(async (start: string, end: string) => {
     if (!start || !end) return;


### PR DESCRIPTION
## Summary
This PR addresses query timeout issues and improves the user experience when data refresh fails by preserving stale data instead of clearing the view. It implements client-side request timeouts, distinguishes between initial load failures and refresh failures, and optimizes the backend batch size for Supabase queries.

## Key Changes

**Frontend (src/pages/index.tsx):**
- Added `QUERY_TIMEOUT_MS = 15_000` constant to cap frontend queries at 15 seconds instead of relying on browser defaults (~2 min)
- Implemented `AbortController` with timeout to fail fast on slow queries
- Added `hasDataRef` to track whether the first successful fetch has completed, enabling context-aware error messages
- Modified error handling to preserve existing records on refresh failure instead of clearing them with `setRecords([])`
- Error messages now distinguish between:
  - Initial load failure: show raw error message
  - Refresh failure with stale data: show "Last refresh failed — showing previous data (reason)"
- Added special handling for `AbortError` to display timeout-specific messaging
- Added `finally` block to ensure abort timer is cleared in all code paths

**Backend (src/app/api/tests/route.ts):**
- Increased `BATCH` size from 1000 to 5000 to match Supabase `max_rows` configuration
- Replaced `SELECT *` with explicit column list to reduce payload size and improve query performance
- Updated pagination logic to handle the new batch size efficiently

**Tests (src/__tests__/HomePage.test.tsx):**
- Added comprehensive test suite for error and timeout behavior:
  - Verifies stale records remain visible when a subsequent fetch fails
  - Confirms error banner appears in a section (non-modal) when refresh fails with existing data
  - Tests timeout message display when fetch is aborted

**Documentation (docs/backlog.md):**
- Marked B2 (Query timeout / data refresh UX) as completed with implementation details

## Implementation Details
- The timeout is enforced via `AbortController` signal passed to `fetch()`, ensuring the request is actually cancelled rather than just ignored
- The `hasDataRef` pattern allows graceful degradation: users see stale data with a warning rather than an empty view
- Explicit column selection in the Supabase query reduces network overhead and improves query planning
- All error paths properly clean up the timeout timer to prevent memory leaks

https://claude.ai/code/session_01V6FbQJuVkHTHkJ93uAqv6Z