### PR TITLE
Add error search filtering and expandable error details in tables

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,6 +16,8 @@
 | I1 | Filter state: URL query params seed initial useState values on page mount (Option B) |
 | U3 | Clickable fixture / SN / tester in detail table → apply/toggle as filter |
 | U4 | Product name filter dropdown in header; options fetched from Supabase / fixture |
+| U5 | Error name text filter in error selection lists (header + range summary); shared `useErrorSearch` hook + `ErrorSearchInput` component |
+| U7 | Detail table errors column: foldable with readings sub-table (first 3 collapsed, "Show all (N)" expands inline table with measured/limits/unit) |
 
 ---
 
@@ -38,18 +40,6 @@
 ## ✨ UI / UX Improvements
 
 
-### U5 — Error name text filter in error selection lists
-**Problem:** Error selection lists (in the header and in range summary) have no search/filter, making it hard to find specific errors when the list is long.
-
-**Required behavior:**
-- Add a text input to filter error names in both the header error selector and the range summary error selector
-- Same pattern in both locations — build once, reuse
-
-**Effort:** Small
-**Notes:** Self-contained, no shared filter state changes needed.
-
----
-
 ### U6 — Detail table: global filter text box
 **Problem:** No free-text search across the detail table. Filters currently require clicking specific fields (post-U3) or using header controls.
 
@@ -60,19 +50,6 @@
 
 **Effort:** Medium-Large
 **Dependency:** Do after U3 + U4. U6 should be an extension of the shared filter state established there — not a parallel implementation. Doing U6 standalone risks duplicate/conflicting filter logic.
-
----
-
-### U7 — Detail table "errors" column: foldable with readings
-**Problem:** The errors column can be very long, making rows hard to scan. Individual error readings (measured value, limits, threshold, unit) are not visible in the table view.
-
-**Required behavior:**
-- Show first 3 errors collapsed by default
-- "Show all" expands to a sub-table with all errors and their readings: `measured_value`, `high_limit`, `low_limit`, `threshold`, `unit`
-- Collapse/expand is per-row
-
-**Effort:** Medium
-**Notes:** Pure UI change — all readings data is already in `test_errors`. No query changes needed.
 
 ---
 
@@ -115,6 +92,6 @@
 2. ~~**U3 + U4** — Clickable filters + product filter header. Build on I1.~~ ✅ Done
 3. **B2** — Query timeout / data refresh UX. Independent, but affects daily usability.
 4. **U6** — Detail table text filter. Extends I1/U3/U4 filter state.
-5. **U5, U7** — Self-contained UI improvements, do in any order.
+5. ~~**U5, U7** — Self-contained UI improvements, do in any order.~~ ✅ Done
 6. **F1** — AI chat. Highest payoff, all prerequisites in place by this point.
 7. **F2** — When a sample log file is available.

--- a/src/__tests__/DetailTable.test.tsx
+++ b/src/__tests__/DetailTable.test.tsx
@@ -138,4 +138,64 @@ describe('DetailTable', () => {
     render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
     expect(screen.getByText('c01')).toBeInTheDocument();
   });
+
+  it('U7: shows first 3 errors collapsed, all 5 after toggle', () => {
+    const makeError = (loc: string) => ({
+      error_type: 'analog',
+      location: loc,
+      subtest: null,
+      part_spec: '1UF',
+      unit: 'FARADS',
+      measured_raw: '0.78u',
+      nominal_raw: '1.0u',
+      high_limit_raw: '1.2u',
+      low_limit_raw: '0.8u',
+      threshold_raw: null,
+    });
+    const row = makeRecord({
+      id: 42,
+      serial_number: 'SN-005',
+      result: 'fail',
+      test_errors: ['e01', 'e02', 'e03', 'e04', 'e05'].map(makeError),
+    });
+    render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
+
+    // Initially collapsed: first 3 visible, 4th and 5th not
+    expect(screen.getByText('e01, e02, e03')).toBeInTheDocument();
+    expect(screen.queryByText('e04')).not.toBeInTheDocument();
+    expect(screen.queryByText('e05')).not.toBeInTheDocument();
+
+    // Expand via toggle button
+    fireEvent.click(screen.getByRole('button', { name: 'Show all (5)' }));
+
+    // All 5 now visible as table rows
+    expect(screen.getByRole('cell', { name: 'e01' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'e04' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'e05' })).toBeInTheDocument();
+  });
+
+  it('U7: rows with 3 or fewer errors show all with no toggle', () => {
+    const makeError = (loc: string) => ({
+      error_type: 'analog',
+      location: loc,
+      subtest: null,
+      part_spec: '1UF',
+      unit: 'FARADS',
+      measured_raw: '0.78u',
+      nominal_raw: '1.0u',
+      high_limit_raw: '1.2u',
+      low_limit_raw: '0.8u',
+      threshold_raw: null,
+    });
+    const row = makeRecord({
+      id: 43,
+      serial_number: 'SN-006',
+      result: 'fail',
+      test_errors: ['f01', 'f02', 'f03'].map(makeError),
+    });
+    render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
+
+    expect(screen.getByText('f01, f02, f03')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show all/ })).not.toBeInTheDocument();
+  });
 });

--- a/src/__tests__/ErrorSearchList.test.tsx
+++ b/src/__tests__/ErrorSearchList.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterPanel } from '@/components/FilterPanel';
+
+const ERROR_OPTIONS = ['U1_analog', 'U2_digital', 'R5_shorts', 'C3_analog', 'X9_digital'];
+
+function renderWithErrors(metric = 'errors') {
+  return render(
+    <FilterPanel
+      onReload={() => undefined}
+      rangePreset="7"
+      onRangePresetChange={() => undefined}
+      startDate="2024-05-01"
+      endDate="2024-05-02"
+      onStartDateChange={() => undefined}
+      onEndDateChange={() => undefined}
+      metric={metric}
+      onMetricChange={() => undefined}
+      categoryOptions={[]}
+      categorySelection="top"
+      onCategoryChange={() => undefined}
+      errorOptions={ERROR_OPTIONS}
+      selectedErrors={new Set()}
+      onErrorToggle={() => undefined}
+    />
+  );
+}
+
+describe('ErrorSearchList (U5)', () => {
+  it('shows search input when metric is errors', () => {
+    renderWithErrors();
+    expect(screen.getByPlaceholderText('Search errors...')).toBeInTheDocument();
+  });
+
+  it('shows all errors initially', () => {
+    renderWithErrors();
+    for (const name of ERROR_OPTIONS) {
+      expect(screen.getByText(new RegExp(name))).toBeInTheDocument();
+    }
+  });
+
+  it('filters to matching errors only (case-insensitive substring)', () => {
+    renderWithErrors();
+    fireEvent.change(screen.getByPlaceholderText('Search errors...'), { target: { value: 'analog' } });
+    expect(screen.getByText(/U1_analog/)).toBeInTheDocument();
+    expect(screen.getByText(/C3_analog/)).toBeInTheDocument();
+    expect(screen.queryByText(/U2_digital/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/R5_shorts/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/X9_digital/)).not.toBeInTheDocument();
+  });
+
+  it('matches case-insensitively', () => {
+    renderWithErrors();
+    fireEvent.change(screen.getByPlaceholderText('Search errors...'), { target: { value: 'DIGITAL' } });
+    expect(screen.getByText(/U2_digital/)).toBeInTheDocument();
+    expect(screen.getByText(/X9_digital/)).toBeInTheDocument();
+    expect(screen.queryByText(/U1_analog/)).not.toBeInTheDocument();
+  });
+
+  it('shows all errors when search is cleared', () => {
+    renderWithErrors();
+    const input = screen.getByPlaceholderText('Search errors...');
+    fireEvent.change(input, { target: { value: 'analog' } });
+    fireEvent.change(input, { target: { value: '' } });
+    for (const name of ERROR_OPTIONS) {
+      expect(screen.getByText(new RegExp(name))).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -30,11 +30,9 @@ function getSupabaseForUser(authHeader: string): SupabaseClient {
 }
 
 async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string): Promise<TestRecord[]> {
-  // Supabase PostgREST caps responses at max_rows (server default 1000) per request.
+  // Supabase PostgREST caps responses at max_rows (default 1000) per request.
   // Use .range() in a loop to paginate past that limit and retrieve all records.
-  // Advance by data.length (not a fixed BATCH) so the loop is correct regardless
-  // of the server's max_rows setting. Stop only when the page is empty.
-  const PAGE_SIZE = 1000;
+  const BATCH = 1000;
   const allRows: any[] = [];
   let from = 0;
 
@@ -51,13 +49,14 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
       .lte('start_time', end + 'T23:59:59Z')
       .order('start_time', { ascending: false })
       .order('id', { ascending: false })
-      .range(from, from + PAGE_SIZE - 1);
+      .range(from, from + BATCH - 1);
 
     if (error) throw new Error(`Supabase query failed: ${error.message}`);
     if (!data || data.length === 0) break;
 
     allRows.push(...data);
-    from += data.length; // advance by actual rows returned, not PAGE_SIZE
+    if (data.length < BATCH) break; // last page reached
+    from += BATCH;
   }
 
   return allRows.map((row: any): TestRecord => ({

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -30,9 +30,11 @@ function getSupabaseForUser(authHeader: string): SupabaseClient {
 }
 
 async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string): Promise<TestRecord[]> {
-  // Supabase PostgREST caps responses at max_rows (default 1000) per request.
+  // Supabase PostgREST caps responses at max_rows (server default 1000) per request.
   // Use .range() in a loop to paginate past that limit and retrieve all records.
-  const BATCH = 1000;
+  // Advance by data.length (not a fixed BATCH) so the loop is correct regardless
+  // of the server's max_rows setting. Stop only when the page is empty.
+  const PAGE_SIZE = 1000;
   const allRows: any[] = [];
   let from = 0;
 
@@ -49,14 +51,13 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
       .lte('start_time', end + 'T23:59:59Z')
       .order('start_time', { ascending: false })
       .order('id', { ascending: false })
-      .range(from, from + BATCH - 1);
+      .range(from, from + PAGE_SIZE - 1);
 
     if (error) throw new Error(`Supabase query failed: ${error.message}`);
     if (!data || data.length === 0) break;
 
     allRows.push(...data);
-    if (data.length < BATCH) break; // last page reached
-    from += BATCH;
+    from += data.length; // advance by actual rows returned, not PAGE_SIZE
   }
 
   return allRows.map((row: any): TestRecord => ({

--- a/src/components/DetailTable.tsx
+++ b/src/components/DetailTable.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import type { TestRecord } from '@/lib/testUtils';
+import React, { useState } from 'react';
+import type { TestErrorRecord, TestRecord } from '@/lib/testUtils';
 
 type DetailTableProps = {
   rows: TestRecord[];
@@ -15,6 +15,73 @@ type DetailTableProps = {
   activeTester?: string;
 };
 
+const COLLAPSED_COUNT = 3;
+
+function dash(value: string | null | undefined): string {
+  return value == null || value === '' ? '—' : value;
+}
+
+function ErrorsCell({ errors, expanded, onToggle }: { errors: TestErrorRecord[]; expanded: boolean; onToggle: () => void }) {
+  if (errors.length === 0) return <span>—</span>;
+
+  if (errors.length <= COLLAPSED_COUNT) {
+    return <span>{errors.map((e) => e.location).join(', ')}</span>;
+  }
+
+  if (!expanded) {
+    return (
+      <div>
+        <span>{errors.slice(0, COLLAPSED_COUNT).map((e) => e.location).join(', ')}</span>
+        <div>
+          <button
+            type="button"
+            onClick={onToggle}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
+          >
+            Show all ({errors.length})
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <table style={{ fontSize: '12px', borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Error</th>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Measured</th>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>High limit</th>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Low limit</th>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Threshold</th>
+            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Unit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {errors.map((e) => (
+            <tr key={e.location}>
+              <td style={{ padding: '2px 6px 2px 0' }}>{e.location}</td>
+              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.measured_raw)}</td>
+              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.high_limit_raw)}</td>
+              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.low_limit_raw)}</td>
+              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.threshold_raw)}</td>
+              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.unit)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
+      >
+        Show less
+      </button>
+    </div>
+  );
+}
+
 export function DetailTable({
   rows,
   page,
@@ -28,10 +95,23 @@ export function DetailTable({
   activeSn,
   activeTester,
 }: DetailTableProps) {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
   const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
   const currentPage = Math.min(page, totalPages);
   const start = (currentPage - 1) * pageSize;
   const pageRows = rows.slice(start, start + pageSize);
+
+  function toggleRow(id: number) {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
 
   return (
     <section className="section card">
@@ -134,7 +214,13 @@ export function DetailTable({
                   ) : row.fixture_id}
                 </td>
                 <td>{row.operator_id}</td>
-                <td>{row.test_errors.length > 0 ? row.test_errors.map((e) => e.location).join(', ') : '—'}</td>
+                <td>
+                  <ErrorsCell
+                    errors={row.test_errors}
+                    expanded={expandedRows.has(row.id)}
+                    onToggle={() => toggleRow(row.id)}
+                  />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/components/ErrorSearchInput.tsx
+++ b/src/components/ErrorSearchInput.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type ErrorSearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function ErrorSearchInput({ value, onChange }: ErrorSearchInputProps) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Search errors..."
+      className="header-select"
+      aria-label="Search errors"
+      style={{ fontSize: '12px' }}
+    />
+  );
+}

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { useErrorSearch } from '@/lib/useErrorSearch';
+import { ErrorSearchInput } from '@/components/ErrorSearchInput';
 
 type FilterPanelProps = {
   onReload: () => void;
@@ -37,6 +39,7 @@ export function FilterPanel({
   errorCounts = new Map(),
 }: FilterPanelProps) {
   const [errorListExpanded, setErrorListExpanded] = useState(false);
+  const { query: errorSearchQuery, setQuery: setErrorSearchQuery, filtered: filteredErrorOptions } = useErrorSearch(errorOptions, metric === 'errors');
   return (
     <>
       <span className="header-control-group">
@@ -114,7 +117,11 @@ export function FilterPanel({
           <span className="header-label">
             Error types ({selectedErrors.size === 0 ? errorOptions.length : selectedErrors.size} of {errorOptions.length})
           </span>
-          {(errorListExpanded ? errorOptions : errorOptions.slice(0, 5)).map((error) => (
+          <ErrorSearchInput value={errorSearchQuery} onChange={setErrorSearchQuery} />
+          {(errorSearchQuery.trim()
+            ? filteredErrorOptions
+            : errorListExpanded ? errorOptions : errorOptions.slice(0, 5)
+          ).map((error) => (
             <label key={error} className="badge">
               <input
                 type="checkbox"
@@ -124,7 +131,7 @@ export function FilterPanel({
               <span>{error} ({errorCounts.get(error) ?? 0})</span>
             </label>
           ))}
-          {errorOptions.length > 5 && (
+          {!errorSearchQuery.trim() && errorOptions.length > 5 && (
             <button
               type="button"
               onClick={() => setErrorListExpanded((v) => !v)}

--- a/src/lib/useErrorSearch.ts
+++ b/src/lib/useErrorSearch.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect, useMemo } from 'react';
+
+/**
+ * Manages a case-insensitive substring filter over a list of strings.
+ * Resets the query whenever `open` changes (handles "clear on reopen").
+ */
+export function useErrorSearch(items: string[], open: boolean) {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    setQuery('');
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return items;
+    const q = query.toLowerCase();
+    return items.filter((item) => item.toLowerCase().includes(q));
+  }, [items, query]);
+
+  return { query, setQuery, filtered };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,8 @@ import { FilterPanel } from '@/components/FilterPanel';
 import { StatusBanner } from '@/components/StatusBanner';
 import { clearGuestMode, useAuth } from '@/lib/auth-context';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
+import { ErrorSearchInput } from '@/components/ErrorSearchInput';
+import { useErrorSearch } from '@/lib/useErrorSearch';
 import {
   buildErrorCounts,
   buildUtilization,
@@ -226,6 +228,12 @@ export default function HomePage() {
 
     return { totalTests: rowsFiltered.length, uniqueBoardCount: uniqueBoards.size, passCount, failCount, allErrorsSorted };
   }, [rowsFiltered]);
+
+  const summaryErrorNames = useMemo(
+    () => (summaryStats ? summaryStats.allErrorsSorted.map(([loc]) => loc) : []),
+    [summaryStats]
+  );
+  const { query: summaryErrorQuery, setQuery: setSummaryErrorQuery, filtered: filteredSummaryErrorNames } = useErrorSearch(summaryErrorNames, summaryErrorsExpanded);
 
   // Utilization summary items (for utilization metric)
   const utilizationSummaryItems = useMemo(() => {
@@ -528,23 +536,28 @@ export default function HomePage() {
                 {summaryStats.allErrorsSorted.length === 0 ? (
                   <span style={{ color: '#6b7280', fontSize: '13px' }}>None</span>
                 ) : (
-                  <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0', display: 'grid', gap: '4px' }}>
-                    {(summaryErrorsExpanded
-                      ? summaryStats.allErrorsSorted
-                      : summaryStats.allErrorsSorted.slice(0, 3)
-                    ).map(([loc, count]) => (
-                      <li key={loc} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px' }}>
-                        <span>{loc}</span>
-                        <button
-                          type="button"
-                          className="summary-num"
-                          onClick={() => handleSummaryErrorClick(loc)}
-                        >
-                          {count}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
+                  <>
+                    <ErrorSearchInput value={summaryErrorQuery} onChange={setSummaryErrorQuery} />
+                    <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0', display: 'grid', gap: '4px' }}>
+                      {(summaryErrorQuery.trim()
+                        ? summaryStats.allErrorsSorted.filter(([loc]) => filteredSummaryErrorNames.includes(loc))
+                        : summaryErrorsExpanded
+                          ? summaryStats.allErrorsSorted
+                          : summaryStats.allErrorsSorted.slice(0, 3)
+                      ).map(([loc, count]) => (
+                        <li key={loc} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '13px' }}>
+                          <span>{loc}</span>
+                          <button
+                            type="button"
+                            className="summary-num"
+                            onClick={() => handleSummaryErrorClick(loc)}
+                          >
+                            {count}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
                 )}
               </li>
             </ul>


### PR DESCRIPTION
## Summary
This PR implements two UI improvements for better error visibility and searchability:
1. **Error search filtering** — Add text input to filter error names in error selection lists (header and range summary)
2. **Expandable error details** — Make the detail table errors column foldable, showing first 3 errors collapsed with a "Show all" toggle that expands to a sub-table with full readings

## Key Changes

### New Components & Hooks
- **`ErrorSearchInput`** — Reusable text input component for filtering error names
- **`useErrorSearch`** — Custom hook managing case-insensitive substring filtering over error lists, with auto-reset when panel opens/closes

### DetailTable Enhancements
- Added `ErrorsCell` component to handle error display with collapsible behavior
  - Shows all errors inline if ≤3 errors
  - Shows first 3 + "Show all (N)" button if >3 errors
  - Expands to a detailed sub-table with columns: Error, Measured, High limit, Low limit, Threshold, Unit
  - Per-row expand/collapse state managed via `expandedRows` Set
- Added `dash()` utility to display "—" for null/empty values
- Updated error column rendering to use new `ErrorsCell` component

### FilterPanel Updates
- Integrated `useErrorSearch` hook for error type filtering
- Added `ErrorSearchInput` above error checkbox list
- Filter respects "Show all" expansion state — search results bypass the 5-item limit
- Automatically clears search query when metric changes away from "errors"

### HomePage Updates
- Added error search for the range summary error list
- Integrated `ErrorSearchInput` and `useErrorSearch` for summary errors
- Search results bypass the 3-item collapsed limit in summary view

### Tests
- Added comprehensive test suite for error search functionality (`ErrorSearchList.test.tsx`)
  - Validates case-insensitive substring matching
  - Confirms search clears when input is emptied
- Added tests for detail table error expansion (`DetailTable.test.tsx`)
  - Verifies first 3 errors shown collapsed, all visible after toggle
  - Confirms rows with ≤3 errors show all without toggle button

### Documentation
- Updated `backlog.md` to mark U5 and U7 as completed
- Moved completed items from "Planned" to "Done" section

## Implementation Details
- Error filtering uses case-insensitive `toLowerCase().includes()` for substring matching
- Expand/collapse state is per-row, independent across multiple rows
- Sub-table uses inline styles for consistency with existing codebase
- Search input automatically resets when the containing panel opens/closes (via `useErrorSearch` dependency on `open` prop)
- All error reading data (`measured_raw`, `high_limit_raw`, etc.) already exists in `TestErrorRecord` — no schema changes needed

https://claude.ai/code/session_01Fjf8UKUK9faVgHq7VeramN