### PR TITLE
perf: decouple test_errors from main /api/tests query

### DIFF
--- a/src/__tests__/DetailTable.test.tsx
+++ b/src/__tests__/DetailTable.test.tsx
@@ -176,7 +176,7 @@ describe('DetailTable', () => {
     expect(screen.queryByText('e05')).not.toBeInTheDocument();
 
     // Expand via toggle button — triggers fetch
-    fireEvent.click(screen.getByRole('button', { name: 'Show all (5)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand errors' }));
 
     // After fetch resolves, all 5 now visible as table rows
     await waitFor(() => {
@@ -245,7 +245,7 @@ describe('DetailTable', () => {
     });
   });
 
-  it('U7: rows with 3 or fewer errors show all with no toggle', () => {
+  it('U7: rows with 3 or fewer errors show all locations and have expand icon', () => {
     const row = makeRecord({
       id: 43,
       serial_number: 'SN-006',
@@ -256,6 +256,6 @@ describe('DetailTable', () => {
     render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
 
     expect(screen.getByText('f01, f02, f03')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Show all/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Expand errors' })).toBeInTheDocument();
   });
 });

--- a/src/__tests__/DetailTable.test.tsx
+++ b/src/__tests__/DetailTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { DetailTable } from '@/components/DetailTable';
 import type { TestRecord } from '@/lib/testUtils';
 
@@ -18,6 +18,7 @@ function makeRecord(overrides: Partial<TestRecord> & { id: number; serial_number
     product_id:   'PART-REDACTED-001',
     product_name: 'Test Product A',
     part_number:  'PART-REDACTED-001',
+    error_locations: [],
     test_errors:  [],
     ...overrides,
   };
@@ -131,15 +132,14 @@ describe('DetailTable', () => {
       id: 1,
       serial_number: 'SN-001',
       result: 'fail',
-      test_errors: [
-        { error_type: 'analog', location: 'c01', subtest: null, part_spec: '1UF', unit: 'FARADS', measured_raw: '0.78327u', nominal_raw: '1.0000u', high_limit_raw: '1.2000u', low_limit_raw: '0.80000u', threshold_raw: null },
-      ],
+      error_locations: ['c01'],
+      test_errors: [],
     });
     render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
     expect(screen.getByText('c01')).toBeInTheDocument();
   });
 
-  it('U7: shows first 3 errors collapsed, all 5 after toggle', () => {
+  it('U7: shows first 3 errors collapsed, all 5 after toggle (on-demand fetch)', async () => {
     const makeError = (loc: string) => ({
       error_type: 'analog',
       location: loc,
@@ -156,8 +156,18 @@ describe('DetailTable', () => {
       id: 42,
       serial_number: 'SN-005',
       result: 'fail',
-      test_errors: ['e01', 'e02', 'e03', 'e04', 'e05'].map(makeError),
+      error_locations: ['e01', 'e02', 'e03', 'e04', 'e05'],
+      test_errors: [],
     });
+
+    // Mock fetch for on-demand error loading
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        errors: { '42': ['e01', 'e02', 'e03', 'e04', 'e05'].map(makeError) },
+      }),
+    });
+
     render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
 
     // Initially collapsed: first 3 visible, 4th and 5th not
@@ -165,13 +175,15 @@ describe('DetailTable', () => {
     expect(screen.queryByText('e04')).not.toBeInTheDocument();
     expect(screen.queryByText('e05')).not.toBeInTheDocument();
 
-    // Expand via toggle button
+    // Expand via toggle button — triggers fetch
     fireEvent.click(screen.getByRole('button', { name: 'Show all (5)' }));
 
-    // All 5 now visible as table rows
-    expect(screen.getByRole('cell', { name: 'e01' })).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: 'e04' })).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: 'e05' })).toBeInTheDocument();
+    // After fetch resolves, all 5 now visible as table rows
+    await waitFor(() => {
+      expect(screen.getByRole('cell', { name: 'e01' })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'e04' })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'e05' })).toBeInTheDocument();
+    });
   });
 
   describe('U6 — text filter input', () => {
@@ -234,23 +246,12 @@ describe('DetailTable', () => {
   });
 
   it('U7: rows with 3 or fewer errors show all with no toggle', () => {
-    const makeError = (loc: string) => ({
-      error_type: 'analog',
-      location: loc,
-      subtest: null,
-      part_spec: '1UF',
-      unit: 'FARADS',
-      measured_raw: '0.78u',
-      nominal_raw: '1.0u',
-      high_limit_raw: '1.2u',
-      low_limit_raw: '0.8u',
-      threshold_raw: null,
-    });
     const row = makeRecord({
       id: 43,
       serial_number: 'SN-006',
       result: 'fail',
-      test_errors: ['f01', 'f02', 'f03'].map(makeError),
+      error_locations: ['f01', 'f02', 'f03'],
+      test_errors: [],
     });
     render(<DetailTable rows={[row]} page={1} pageSize={10} onPageChange={jest.fn()} title="Test" />);
 

--- a/src/__tests__/HomePage.test.tsx
+++ b/src/__tests__/HomePage.test.tsx
@@ -79,6 +79,7 @@ const MOCK_RECORD: TestRecord = {
   product_id: 'PART-REDACTED-001',
   product_name: 'Test Product A',
   part_number: 'PART-REDACTED-001',
+  error_locations: [],
   test_errors: [],
 };
 
@@ -241,6 +242,7 @@ describe('HomePage', () => {
       fixture_id: 'fix-alpha',
       operator_id: 'op-alpha',
       board_id: 'SN-ALPHA-001',
+      error_locations: [],
       test_errors: [],
     };
     const RECORD_B: TestRecord = {
@@ -252,6 +254,7 @@ describe('HomePage', () => {
       fixture_id: 'fix-beta',
       operator_id: 'op-beta',
       board_id: 'SN-BETA-002',
+      error_locations: [],
       test_errors: [],
     };
     const RECORD_WITH_ERROR: TestRecord = {
@@ -264,18 +267,8 @@ describe('HomePage', () => {
       operator_id: 'op-err',
       board_id: 'SN-ERR-003',
       result: 'fail',
-      test_errors: [{
-        error_type: 'analog',
-        location: 'resistor-R42',
-        subtest: null,
-        part_spec: '10K',
-        unit: 'OHM',
-        measured_raw: '5K',
-        nominal_raw: '10K',
-        high_limit_raw: '11K',
-        low_limit_raw: '9K',
-        threshold_raw: null,
-      }],
+      error_locations: ['resistor-R42'],
+      test_errors: [],
     };
 
     beforeEach(() => {

--- a/src/__tests__/ict-db.test.ts
+++ b/src/__tests__/ict-db.test.ts
@@ -117,7 +117,7 @@ describe('upsertTest', () => {
     });
   });
 
-  it('calls from("tests").upsert with correct fields', async () => {
+  it('calls from("tests").upsert with correct fields including error_locations', async () => {
     await upsertTest(PARSED);
     expect(mockFrom.mock.calls[2][0]).toBe('tests');
     const upsertArg = mockFrom.mock.results[2].value.upsert.mock.calls[0][0];
@@ -126,6 +126,7 @@ describe('upsertTest', () => {
       result:      'pass',
       operator_id: 'operator-01',
       source_file: 'PROD-001_SN-XXXX-000001.log',
+      error_locations: ['c01'],
     });
   });
 

--- a/src/__tests__/test-errors-route.test.ts
+++ b/src/__tests__/test-errors-route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ *
+ * test-errors-route.test.ts
+ *
+ * Tests for GET /api/test-errors — on-demand error detail endpoint.
+ */
+import { NextRequest } from 'next/server';
+
+// Mock Supabase
+const mockIn = jest.fn();
+const mockSelect = jest.fn().mockReturnValue({ in: mockIn });
+const mockFrom = jest.fn().mockReturnValue({ select: mockSelect });
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: mockFrom })),
+}));
+
+// Mock fs for fixture loading
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockReturnValue(JSON.stringify({
+    test_errors: [
+      {
+        test_id: 1,
+        error_type: 'analog',
+        location: 'c01',
+        subtest: null,
+        part_spec: '1UF',
+        unit: 'FARADS',
+        measured_raw: '0.78u',
+        nominal_raw: '1.0u',
+        high_limit_raw: '1.2u',
+        low_limit_raw: '0.8u',
+        threshold_raw: null,
+      },
+      {
+        test_id: 2,
+        error_type: 'digital',
+        location: 'u05',
+        subtest: 'pin3',
+        part_spec: 'IC',
+        unit: 'VOLTS',
+        measured_raw: '0.5',
+        nominal_raw: '3.3',
+        high_limit_raw: '3.6',
+        low_limit_raw: '3.0',
+        threshold_raw: null,
+      },
+      {
+        test_id: 1,
+        error_type: 'analog',
+        location: 'r10',
+        subtest: null,
+        part_spec: '10K',
+        unit: 'OHMS',
+        measured_raw: '15K',
+        nominal_raw: '10K',
+        high_limit_raw: '11K',
+        low_limit_raw: '9K',
+        threshold_raw: null,
+      },
+    ],
+  })),
+}));
+
+import { GET } from '@/app/api/test-errors/route';
+
+function makeRequest(url: string, headers?: Record<string, string>): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost'), {
+    headers: headers ?? {},
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+});
+
+describe('GET /api/test-errors', () => {
+  describe('validation', () => {
+    it('returns 400 when testIds is missing', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors'));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/testIds/);
+    });
+
+    it('returns 400 when testIds contains non-integers', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors?testIds=abc,2'));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when testIds is empty', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors?testIds='));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('guest path (fixture)', () => {
+    it('returns filtered errors from fixture by testIds', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors?testIds=1'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.errors['1']).toHaveLength(2);
+      expect(body.errors['1'][0].location).toBe('c01');
+      expect(body.errors['1'][1].location).toBe('r10');
+    });
+
+    it('returns empty array for testIds with no errors', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors?testIds=999'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.errors['999']).toEqual([]);
+    });
+
+    it('handles multiple testIds', async () => {
+      const res = await GET(makeRequest('http://localhost/api/test-errors?testIds=1,2'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.errors['1']).toHaveLength(2);
+      expect(body.errors['2']).toHaveLength(1);
+      expect(body.errors['2'][0].location).toBe('u05');
+    });
+  });
+
+  describe('authenticated path (Supabase)', () => {
+    it('queries Supabase with testIds and returns mapped errors', async () => {
+      mockIn.mockResolvedValue({
+        data: [
+          {
+            test_id: 5,
+            error_type: 'analog',
+            location: 'c01',
+            subtest: null,
+            part_spec: '1UF',
+            unit: 'FARADS',
+            measured_raw: '0.78u',
+            nominal_raw: '1.0u',
+            high_limit_raw: '1.2u',
+            low_limit_raw: '0.8u',
+            threshold_raw: null,
+          },
+        ],
+        error: null,
+      });
+
+      const res = await GET(makeRequest(
+        'http://localhost/api/test-errors?testIds=5',
+        { authorization: 'Bearer test-jwt' },
+      ));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.errors['5']).toHaveLength(1);
+      expect(body.errors['5'][0].location).toBe('c01');
+
+      expect(mockFrom).toHaveBeenCalledWith('test_errors');
+      expect(mockIn).toHaveBeenCalledWith('test_id', [5]);
+    });
+
+    it('returns 500 when Supabase query fails', async () => {
+      mockIn.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+      const res = await GET(makeRequest(
+        'http://localhost/api/test-errors?testIds=1',
+        { authorization: 'Bearer test-jwt' },
+      ));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toMatch(/DB error/);
+    });
+  });
+});

--- a/src/app/api/test-errors/route.ts
+++ b/src/app/api/test-errors/route.ts
@@ -1,0 +1,134 @@
+/**
+ * GET /api/test-errors?testIds=1,2,3
+ *
+ * Returns full error detail (readings) for a list of test IDs.
+ * Called on-demand when a user expands a row in the detail table.
+ *
+ * Auth: same pattern as /api/tests
+ *   - Authenticated (Authorization: Bearer <jwt>) → Supabase with RLS
+ *   - Guest (no header) → fixture data filtered by testIds
+ *
+ * Response: { errors: Record<string, TestErrorRecord[]> }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import path from 'path';
+import fs from 'fs';
+import type { TestErrorRecord } from '@/lib/testUtils';
+
+function getSupabaseForUser(authHeader: string): SupabaseClient {
+  const url  = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, anon, {
+    global: { headers: { Authorization: authHeader } },
+    auth:   { persistSession: false },
+  }) as SupabaseClient;
+}
+
+function parseTestIds(raw: string | null): number[] | null {
+  if (!raw) return null;
+  const ids: number[] = [];
+  for (const part of raw.split(',')) {
+    const n = Number(part.trim());
+    if (!Number.isInteger(n) || n <= 0) return null;
+    ids.push(n);
+  }
+  return ids.length > 0 ? ids : null;
+}
+
+async function fetchFromSupabase(
+  sb: SupabaseClient,
+  testIds: number[],
+): Promise<Record<string, TestErrorRecord[]>> {
+  const { data, error } = await sb
+    .from('test_errors')
+    .select('test_id, error_type, location, subtest, part_spec, unit, measured_raw, nominal_raw, high_limit_raw, low_limit_raw, threshold_raw')
+    .in('test_id', testIds);
+
+  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+
+  const result: Record<string, TestErrorRecord[]> = {};
+  for (const id of testIds) result[id] = [];
+  for (const row of data ?? []) {
+    const key = String(row.test_id);
+    if (!result[key]) result[key] = [];
+    result[key].push({
+      error_type:     row.error_type,
+      location:       row.location,
+      subtest:        row.subtest,
+      part_spec:      row.part_spec,
+      unit:           row.unit,
+      measured_raw:   row.measured_raw,
+      nominal_raw:    row.nominal_raw,
+      high_limit_raw: row.high_limit_raw,
+      low_limit_raw:  row.low_limit_raw,
+      threshold_raw:  row.threshold_raw,
+    });
+  }
+  return result;
+}
+
+type FixtureData = {
+  test_errors: Array<{
+    test_id: number; error_type: string; location: string; subtest: string | null;
+    part_spec: string; unit: string; measured_raw: string; nominal_raw: string;
+    high_limit_raw: string; low_limit_raw: string; threshold_raw: string | null;
+  }>;
+};
+
+function fetchFromFixture(testIds: number[]): Record<string, TestErrorRecord[]> {
+  const filePath = path.join(process.cwd(), 'src', 'fixtures', 'guest-data.json');
+  const fixture = JSON.parse(fs.readFileSync(filePath, 'utf8')) as FixtureData;
+
+  const idSet = new Set(testIds);
+  const result: Record<string, TestErrorRecord[]> = {};
+  for (const id of testIds) result[id] = [];
+
+  for (const e of fixture.test_errors) {
+    if (!idSet.has(e.test_id)) continue;
+    const key = String(e.test_id);
+    if (!result[key]) result[key] = [];
+    result[key].push({
+      error_type:     e.error_type,
+      location:       e.location,
+      subtest:        e.subtest,
+      part_spec:      e.part_spec,
+      unit:           e.unit,
+      measured_raw:   e.measured_raw,
+      nominal_raw:    e.nominal_raw,
+      high_limit_raw: e.high_limit_raw,
+      low_limit_raw:  e.low_limit_raw,
+      threshold_raw:  e.threshold_raw,
+    });
+  }
+  return result;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const testIds = parseTestIds(searchParams.get('testIds'));
+
+  if (!testIds) {
+    return NextResponse.json(
+      { error: 'testIds query param is required (comma-separated integers)' },
+      { status: 400 },
+    );
+  }
+
+  const authHeader = req.headers.get('authorization');
+
+  if (!authHeader) {
+    const errors = fetchFromFixture(testIds);
+    return NextResponse.json({ errors });
+  }
+
+  try {
+    const sb = getSupabaseForUser(authHeader);
+    const errors = await fetchFromSupabase(sb, testIds);
+    return NextResponse.json({ errors });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -41,10 +41,9 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
     const { data, error } = await sb
       .from('tests')
       .select(`
-        id, board_id, start_time, end_time, result, operator_id, fixture_id, tester, source_file, ingested_at,
+        id, board_id, start_time, end_time, result, operator_id, fixture_id, tester, source_file, ingested_at, error_locations,
         boards!inner (serial_number, mac_address, rev, product_id,
-          products!inner (product_name, part_number)),
-        test_errors (error_type, location, subtest, part_spec, unit, measured_raw, nominal_raw, high_limit_raw, low_limit_raw, threshold_raw)
+          products!inner (product_name, part_number))
       `)
       .gte('start_time', start)
       .lte('start_time', end + 'T23:59:59Z')
@@ -77,7 +76,8 @@ async function fetchFromSupabase(sb: SupabaseClient, start: string, end: string)
     product_id:   row.boards?.product_id     ?? '',
     product_name: row.boards?.products?.product_name ?? '',
     part_number:  row.boards?.products?.part_number  ?? '',
-    test_errors:  (row.test_errors ?? []) as TestErrorRecord[],
+    error_locations: (row.error_locations ?? []) as string[],
+    test_errors:  [],
   }));
 }
 
@@ -172,7 +172,8 @@ function fetchFromFixture(start: string, end: string): TestRecord[] {
       product_id:   board?.product_id     ?? '',
       product_name: product?.product_name ?? '',
       part_number:  product?.part_number  ?? '',
-      test_errors:  errorsByTestId.get(test.id) ?? [],
+      error_locations: (errorsByTestId.get(test.id) ?? []).map((e) => e.location),
+      test_errors:  [],
     });
   }
 

--- a/src/components/DetailTable.tsx
+++ b/src/components/DetailTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { TestErrorRecord, TestRecord } from '@/lib/testUtils';
 
 type DetailTableProps = {
@@ -15,6 +15,7 @@ type DetailTableProps = {
   activeTester?: string;
   textFilter?: string;
   onTextFilterChange?: (value: string) => void;
+  authToken?: string;
 };
 
 const COLLAPSED_COUNT = 3;
@@ -23,63 +24,104 @@ function dash(value: string | null | undefined): string {
   return value == null || value === '' ? '—' : value;
 }
 
-function ErrorsCell({ errors, expanded, onToggle }: { errors: TestErrorRecord[]; expanded: boolean; onToggle: () => void }) {
-  if (errors.length === 0) return <span>—</span>;
+function ErrorsCell({
+  errorLocations,
+  errors,
+  expanded,
+  onToggle,
+  loading,
+}: {
+  errorLocations: string[];
+  errors: TestErrorRecord[];
+  expanded: boolean;
+  onToggle: () => void;
+  loading: boolean;
+}) {
+  if (errorLocations.length === 0 && errors.length === 0) return <span>—</span>;
 
-  if (errors.length <= COLLAPSED_COUNT) {
-    return <span>{errors.map((e) => e.location).join(', ')}</span>;
+  const locations = errors.length > 0 ? errors.map((e) => e.location) : errorLocations;
+
+  if (locations.length <= COLLAPSED_COUNT) {
+    return <span>{locations.join(', ')}</span>;
   }
 
   if (!expanded) {
     return (
       <div>
-        <span>{errors.slice(0, COLLAPSED_COUNT).map((e) => e.location).join(', ')}</span>
+        <span>{locations.slice(0, COLLAPSED_COUNT).join(', ')}</span>
         <div>
           <button
             type="button"
             onClick={onToggle}
             style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
           >
-            Show all ({errors.length})
+            Show all ({locations.length})
           </button>
         </div>
       </div>
     );
   }
 
+  if (loading) {
+    return (
+      <div>
+        <span style={{ fontSize: '12px', color: '#6b7280' }}>Loading error details...</span>
+      </div>
+    );
+  }
+
+  // Expanded — if full errors are available show the detail table, otherwise just locations
+  if (errors.length > 0) {
+    return (
+      <div>
+        <table style={{ fontSize: '12px', borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Error</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Measured</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>High limit</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Low limit</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Threshold</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Unit</th>
+            </tr>
+          </thead>
+          <tbody>
+            {errors.map((e) => (
+              <tr key={e.location}>
+                <td style={{ padding: '2px 6px 2px 0' }}>{e.location}</td>
+                <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.measured_raw)}</td>
+                <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.high_limit_raw)}</td>
+                <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.low_limit_raw)}</td>
+                <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.threshold_raw)}</td>
+                <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.unit)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button
+          type="button"
+          onClick={onToggle}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
+        >
+          Show less
+        </button>
+      </div>
+    );
+  }
+
+  // Fallback: only locations available (fetch may have returned empty)
   return (
     <div>
-      <table style={{ fontSize: '12px', borderCollapse: 'collapse', width: '100%' }}>
-        <thead>
-          <tr>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Error</th>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Measured</th>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>High limit</th>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Low limit</th>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Threshold</th>
-            <th style={{ textAlign: 'left', padding: '2px 6px 2px 0', whiteSpace: 'nowrap' }}>Unit</th>
-          </tr>
-        </thead>
-        <tbody>
-          {errors.map((e) => (
-            <tr key={e.location}>
-              <td style={{ padding: '2px 6px 2px 0' }}>{e.location}</td>
-              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.measured_raw)}</td>
-              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.high_limit_raw)}</td>
-              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.low_limit_raw)}</td>
-              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.threshold_raw)}</td>
-              <td style={{ padding: '2px 6px 2px 0' }}>{dash(e.unit)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <button
-        type="button"
-        onClick={onToggle}
-        style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
-      >
-        Show less
-      </button>
+      <span>{locations.join(', ')}</span>
+      <div>
+        <button
+          type="button"
+          onClick={onToggle}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
+        >
+          Show less
+        </button>
+      </div>
     </div>
   );
 }
@@ -98,23 +140,63 @@ export function DetailTable({
   activeTester,
   textFilter,
   onTextFilterChange,
+  authToken,
 }: DetailTableProps) {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+  const [fetchedErrors, setFetchedErrors] = useState<Map<number, TestErrorRecord[]>>(new Map());
+  const [loadingRows, setLoadingRows] = useState<Set<number>>(new Set());
   const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
   const currentPage = Math.min(page, totalPages);
   const start = (currentPage - 1) * pageSize;
   const pageRows = rows.slice(start, start + pageSize);
 
-  function toggleRow(id: number) {
+  const toggleRow = useCallback((id: number, row: TestRecord) => {
     setExpandedRows((prev) => {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
-      } else {
-        next.add(id);
+        return next;
       }
+      next.add(id);
+
+      // Fetch error details on-demand if not already loaded
+      if (row.test_errors.length === 0 && row.error_locations.length > 0 && !fetchedErrors.has(id) && !loadingRows.has(id)) {
+        setLoadingRows((p) => new Set(p).add(id));
+        const headers: Record<string, string> = {};
+        if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+        fetch(`/api/test-errors?testIds=${id}`, { headers })
+          .then((res) => res.ok ? res.json() as Promise<{ errors: Record<string, TestErrorRecord[]> }> : Promise.resolve({ errors: {} as Record<string, TestErrorRecord[]> }))
+          .then((body) => {
+            setFetchedErrors((prev) => {
+              const next = new Map(prev);
+              next.set(id, body.errors[String(id)] ?? []);
+              return next;
+            });
+          })
+          .catch(() => {
+            // On failure, store empty array so we don't retry endlessly
+            setFetchedErrors((prev) => {
+              const next = new Map(prev);
+              next.set(id, []);
+              return next;
+            });
+          })
+          .finally(() => {
+            setLoadingRows((p) => {
+              const next = new Set(p);
+              next.delete(id);
+              return next;
+            });
+          });
+      }
+
       return next;
     });
+  }, [authToken, fetchedErrors, loadingRows]);
+
+  function getRowErrors(row: TestRecord): TestErrorRecord[] {
+    if (row.test_errors.length > 0) return row.test_errors;
+    return fetchedErrors.get(row.id) ?? [];
   }
 
   return (
@@ -245,9 +327,11 @@ export function DetailTable({
                 <td>{row.operator_id}</td>
                 <td>
                   <ErrorsCell
-                    errors={row.test_errors}
+                    errorLocations={row.error_locations}
+                    errors={getRowErrors(row)}
                     expanded={expandedRows.has(row.id)}
-                    onToggle={() => toggleRow(row.id)}
+                    onToggle={() => toggleRow(row.id, row)}
+                    loading={loadingRows.has(row.id)}
                   />
                 </td>
               </tr>

--- a/src/components/DetailTable.tsx
+++ b/src/components/DetailTable.tsx
@@ -41,23 +41,23 @@ function ErrorsCell({
 
   const locations = errors.length > 0 ? errors.map((e) => e.location) : errorLocations;
 
-  if (locations.length <= COLLAPSED_COUNT) {
-    return <span>{locations.join(', ')}</span>;
-  }
-
   if (!expanded) {
+    const display = locations.length <= COLLAPSED_COUNT
+      ? locations.join(', ')
+      : locations.slice(0, COLLAPSED_COUNT).join(', ');
     return (
-      <div>
-        <span>{locations.slice(0, COLLAPSED_COUNT).join(', ')}</span>
-        <div>
-          <button
-            type="button"
-            onClick={onToggle}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', color: '#4338ca', padding: '2px 0' }}
-          >
-            Show all ({locations.length})
-          </button>
-        </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <span>{display}</span>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label="Expand errors"
+          title="Show error details"
+          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '14px', color: '#4338ca', padding: '0 2px', lineHeight: 1 }}
+        >
+          {locations.length > COLLAPSED_COUNT ? `+${locations.length - COLLAPSED_COUNT}` : ''}
+          <span style={{ fontSize: '12px', verticalAlign: 'middle' }}> ▶</span>
+        </button>
       </div>
     );
   }

--- a/src/lib/ict-db.ts
+++ b/src/lib/ict-db.ts
@@ -70,6 +70,7 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
   const boardId = boardData!.id as string;
 
   // 3. tests — upsert with ignoreDuplicates so we can detect new vs existing
+  const locations = parsed.errors.map((e) => e.location);
   const { data: testData, error: testErr } = await sb
     .from('tests')
     .upsert(
@@ -82,6 +83,7 @@ export async function upsertTest(parsed: ParsedTest): Promise<void> {
         fixture_id:  parsed.fixture_id,
         tester:      parsed.tester,
         source_file: parsed.source_file,
+        error_locations: locations,
       },
       { onConflict: 'board_id,start_time,end_time', ignoreDuplicates: true }
     )

--- a/src/lib/testUtils.ts
+++ b/src/lib/testUtils.ts
@@ -38,7 +38,9 @@ export type TestRecord = {
   // from products join:
   product_name: string;
   part_number: string;
-  // from test_errors join:
+  // Denormalised from test_errors — location codes only (for filtering / summary).
+  error_locations: string[];
+  // Full error detail — populated on-demand via /api/test-errors, empty by default.
   test_errors: TestErrorRecord[];
 };
 
@@ -83,8 +85,11 @@ export function buildSummary(records: TestRecord[]): string[] {
 
   const errorCounts: Record<string, number> = {};
   records.forEach((r) => {
-    r.test_errors.forEach((e) => {
-      errorCounts[e.location] = (errorCounts[e.location] ?? 0) + 1;
+    const locations = r.test_errors.length > 0
+      ? r.test_errors.map((e) => e.location)
+      : r.error_locations;
+    locations.forEach((loc) => {
+      errorCounts[loc] = (errorCounts[loc] ?? 0) + 1;
     });
   });
   const topErrors = Object.entries(errorCounts)
@@ -107,9 +112,12 @@ export function buildErrorCounts(records: TestRecord[]): {
   const allErrors = new Set<string>();
   const counts = new Map<string, number>();
   records.forEach((r) => {
-    r.test_errors.forEach((e) => {
-      allErrors.add(e.location);
-      const key = `${getDateKey(r)}::${e.location}`;
+    const locations = r.test_errors.length > 0
+      ? r.test_errors.map((e) => e.location)
+      : r.error_locations;
+    locations.forEach((loc) => {
+      allErrors.add(loc);
+      const key = `${getDateKey(r)}::${loc}`;
       counts.set(key, (counts.get(key) ?? 0) + 1);
     });
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ function matchesTextFilter(r: TestRecord, lower: string): boolean {
     (r.tester ?? '').toLowerCase().includes(lower) ||
     (r.fixture_id ?? '').toLowerCase().includes(lower) ||
     (r.operator_id ?? '').toLowerCase().includes(lower) ||
-    r.test_errors.some((e) => e.location.toLowerCase().includes(lower))
+    r.error_locations.some((loc) => loc.toLowerCase().includes(lower))
   );
 }
 
@@ -276,8 +276,8 @@ export default function HomePage() {
   const errorTotals = useMemo(() => {
     const m = new Map<string, number>();
     filteredRows.forEach((r) => {
-      r.test_errors.forEach((e) => {
-        m.set(e.location, (m.get(e.location) ?? 0) + 1);
+      r.error_locations.forEach((loc) => {
+        m.set(loc, (m.get(loc) ?? 0) + 1);
       });
     });
     return m;
@@ -297,8 +297,8 @@ export default function HomePage() {
 
     const errorCounts: Record<string, number> = {};
     rowsFilteredTextDebounced.forEach((r) => {
-      r.test_errors.forEach((e) => {
-        errorCounts[e.location] = (errorCounts[e.location] ?? 0) + 1;
+      r.error_locations.forEach((loc) => {
+        errorCounts[loc] = (errorCounts[loc] ?? 0) + 1;
       });
     });
     const allErrorsSorted = Object.entries(errorCounts)
@@ -393,7 +393,7 @@ export default function HomePage() {
     let rows = tableFilteredRows;
     if (metric === 'errors' && selectedErrors.size > 0) {
       rows = rows.filter((r) =>
-        r.test_errors.some((e) => selectedErrors.has(e.location))
+        r.error_locations.some((loc) => selectedErrors.has(loc))
       );
     }
 
@@ -657,6 +657,7 @@ export default function HomePage() {
         activeTester={tester}
         textFilter={textFilter}
         onTextFilterChange={(v) => { setTextFilter(v); setPage(1); }}
+        authToken={session?.access_token}
       />
 
       <footer>

--- a/src/pipeline/docs/schema.sql
+++ b/src/pipeline/docs/schema.sql
@@ -64,15 +64,6 @@ ALTER TABLE tests ADD COLUMN IF NOT EXISTS source_file text;
 ALTER TABLE tests ADD COLUMN IF NOT EXISTS ingested_at       timestamptz DEFAULT now();
 ALTER TABLE tests ADD COLUMN IF NOT EXISTS error_locations   text[] DEFAULT '{}';
 
--- Backfill error_locations from existing test_errors rows
-UPDATE tests t SET error_locations = (
-  SELECT COALESCE(ARRAY_AGG(te.location ORDER BY te.location), '{}')
-  FROM test_errors te WHERE te.test_id = t.id
-) WHERE error_locations IS NULL OR error_locations = '{}';
-
--- GIN index for filtering on error_locations
-CREATE INDEX IF NOT EXISTS tests_error_locations_idx ON tests USING GIN (error_locations);
-
 -- Unique dedup constraint — safe for re-ingestion and partial-file scenarios
 DO $$ BEGIN
   ALTER TABLE tests
@@ -113,6 +104,21 @@ ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS low_limit_raw  text;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS threshold_raw   text;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS threshold_value float8;
 ALTER TABLE test_errors ADD COLUMN IF NOT EXISTS raw_block       text;
+
+-- Index on test_id for FK lookups and the backfill query below
+CREATE INDEX IF NOT EXISTS test_errors_test_id_idx ON test_errors (test_id);
+
+-- ============================================================
+-- 4b. Backfill tests.error_locations from test_errors
+-- Must run AFTER test_errors table + index exist.
+-- ============================================================
+UPDATE tests t SET error_locations = (
+  SELECT COALESCE(ARRAY_AGG(te.location ORDER BY te.location), '{}')
+  FROM test_errors te WHERE te.test_id = t.id
+) WHERE error_locations IS NULL OR error_locations = '{}';
+
+-- GIN index for filtering on error_locations (built after backfill for efficiency)
+CREATE INDEX IF NOT EXISTS tests_error_locations_idx ON tests USING GIN (error_locations);
 
 -- ============================================================
 -- 5. Rolling 3-month delete  (pg_cron)

--- a/src/pipeline/docs/schema.sql
+++ b/src/pipeline/docs/schema.sql
@@ -52,15 +52,26 @@ CREATE TABLE IF NOT EXISTS tests (
   operator_id  text,
   fixture_id   text,
   tester       text,
-  source_file  text,                  -- original log filename
-  ingested_at  timestamptz DEFAULT now()
+  source_file      text,                  -- original log filename
+  ingested_at      timestamptz DEFAULT now(),
+  error_locations  text[] DEFAULT '{}'    -- denormalised location codes from test_errors
 );
 
 -- Add new columns if upgrading from an older schema
 ALTER TABLE tests ADD COLUMN IF NOT EXISTS fixture_id  text;
 ALTER TABLE tests ADD COLUMN IF NOT EXISTS tester      text;
 ALTER TABLE tests ADD COLUMN IF NOT EXISTS source_file text;
-ALTER TABLE tests ADD COLUMN IF NOT EXISTS ingested_at timestamptz DEFAULT now();
+ALTER TABLE tests ADD COLUMN IF NOT EXISTS ingested_at       timestamptz DEFAULT now();
+ALTER TABLE tests ADD COLUMN IF NOT EXISTS error_locations   text[] DEFAULT '{}';
+
+-- Backfill error_locations from existing test_errors rows
+UPDATE tests t SET error_locations = (
+  SELECT COALESCE(ARRAY_AGG(te.location ORDER BY te.location), '{}')
+  FROM test_errors te WHERE te.test_id = t.id
+) WHERE error_locations IS NULL OR error_locations = '{}';
+
+-- GIN index for filtering on error_locations
+CREATE INDEX IF NOT EXISTS tests_error_locations_idx ON tests USING GIN (error_locations);
 
 -- Unique dedup constraint — safe for re-ingestion and partial-file scenarios
 DO $$ BEGIN


### PR DESCRIPTION
## Summary

- Remove the `test_errors` nested join from `/api/tests`, replacing it with a denormalised `error_locations TEXT[]` column — drops 30-day response from ~186k rows to ~33k rows
- Add new `GET /api/test-errors?testIds=1,2,3` endpoint for on-demand error detail fetching
- Update frontend to use `error_locations` for filtering, charts, and summary stats; DetailTable lazy-fetches full error detail only when a row is expanded
- DB migration adds `error_locations` column with backfill from existing `test_errors` + GIN index
- Add expand icon (▶) to every error row so users can always trigger the detail view, even for rows with 3 or fewer errors

## Related Issues

- Related to #33

## Changes

| File | What changed |
|------|-------------|
| `src/lib/testUtils.ts` | Added `error_locations: string[]` to `TestRecord`; updated `buildErrorCounts` and `buildSummary` to use it |
| `src/lib/ict-db.ts` | Populate `error_locations` at ingest time |
| `src/app/api/tests/route.ts` | Removed `test_errors` from Supabase select; returns `error_locations` instead |
| `src/app/api/test-errors/route.ts` | **New** — on-demand error detail endpoint (auth + guest paths) |
| `src/pages/index.tsx` | All `r.test_errors` usages in filtering/stats replaced with `r.error_locations` |
| `src/components/DetailTable.tsx` | Lazy-fetches error detail on row expand; uses `error_locations` for collapsed view; added ▶ expand icon to all error rows |
| Tests | Updated existing tests + new `test-errors-route.test.ts` (8 new test cases) |

## Test plan

- [x] `npm test` — 139 tests pass (131 existing + 8 new)
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — production build succeeds
- [ ] Manual: verify guest mode loads without test_errors in payload
- [ ] Manual: verify expanding a row triggers `/api/test-errors` fetch and displays detail

https://claude.ai/code/session_018TtfBsHCFdSZm2aRwLPvnR