### PR TITLE
Address PR #37 review comments

### DIFF
--- a/src/__tests__/summary-route.test.ts
+++ b/src/__tests__/summary-route.test.ts
@@ -19,15 +19,25 @@ const mockMvLte = jest.fn();
 const mockMvGte = jest.fn().mockReturnValue({ lte: mockMvLte });
 const mockMvSelect = jest.fn().mockReturnValue({ gte: mockMvGte });
 
+// Mock for auth.getUser() on the anon-key client (JWT validation)
+const mockGetUser = jest.fn();
+
 jest.mock('@supabase/supabase-js', () => ({
-  createClient: jest.fn(() => ({
-    from: jest.fn().mockImplementation((table: string) => {
-      if (table === 'mv_error_counts_by_day') {
-        return { select: mockMvSelect };
-      }
-      return { select: mockTestsSelect };
-    }),
-  })),
+  createClient: jest.fn((_url: string, key: string) => {
+    // Anon-key client — used only for JWT verification
+    if (key !== 'test-service-key') {
+      return { auth: { getUser: mockGetUser } };
+    }
+    // Service-role client — used for actual queries
+    return {
+      from: jest.fn().mockImplementation((table: string) => {
+        if (table === 'mv_error_counts_by_day') {
+          return { select: mockMvSelect };
+        }
+        return { select: mockTestsSelect };
+      }),
+    };
+  }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -102,6 +112,13 @@ function getToday(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// Set env vars so the mock can distinguish anon vs service-role clients
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+  process.env.SUPABASE_SERVICE_KEY = 'test-service-key';
+});
+
 describe('GET /api/summary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -112,6 +129,8 @@ describe('GET /api/summary', () => {
     mockTestsGte.mockReturnValue({ lte: mockTestsLte });
     mockMvSelect.mockReturnValue({ gte: mockMvGte });
     mockTestsSelect.mockReturnValue({ gte: mockTestsGte });
+    // Default: valid user
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null });
   });
 
   describe('validation', () => {
@@ -226,6 +245,19 @@ describe('GET /api/summary', () => {
         data: [{ day: '2026-03-22', location: 'resistor-R10', error_count: 2 }],
         error: null,
       });
+    });
+
+    it('returns 401 when JWT is invalid', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'invalid token' } });
+
+      const req = makeRequest(
+        { start: '2026-03-22', end: '2026-03-24' },
+        { authorization: 'Bearer invalid-jwt' },
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error: string };
+      expect(body.error).toMatch(/invalid|expired/i);
     });
 
     it('aggregates byDayFixtureTester from Supabase data (3 tests → 2 groups)', async () => {

--- a/src/app/api/summary/route.ts
+++ b/src/app/api/summary/route.ts
@@ -16,15 +16,26 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import path from 'path';
 import fs from 'fs';
 import type { SummaryResponse, SummaryRow, ErrorCountRow } from '@/lib/testUtils';
 
 // ---------------------------------------------------------------------------
-// Supabase live path (service role — server-side aggregation, no per-row RLS)
+// Supabase clients
 // ---------------------------------------------------------------------------
 
+/** Anon-key client scoped to the caller's JWT — used only to verify identity. */
+function getSupabaseForUser(authHeader: string): SupabaseClient {
+  const url  = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL!;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  return createClient(url, anon, {
+    global: { headers: { Authorization: authHeader } },
+    auth:   { persistSession: false },
+  }) as SupabaseClient;
+}
+
+/** Service-role client for server-side aggregation (no per-row RLS). */
 function getSupabaseServiceClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL!;
   const key = process.env.SUPABASE_SERVICE_KEY!;
@@ -279,8 +290,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json(result satisfies SummaryResponse);
   }
 
-  // Authenticated path
+  // Authenticated path — verify the caller's JWT before running service-role queries
   try {
+    const userSb = getSupabaseForUser(authHeader);
+    const { data: { user }, error: authError } = await userSb.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 });
+    }
+
     const result = await fetchSummaryFromSupabase(start, end, filters);
     return NextResponse.json(result satisfies SummaryResponse);
   } catch (err) {

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -61,6 +61,7 @@ function applyFilters(query: any, start: string, end: string, filters: TestsFilt
     .gte('start_time', start)
     .lte('start_time', end + 'T23:59:59Z');
 
+  if (filters.product) q = q.eq('boards.products.product_name', filters.product);
   if (filters.fixture) q = q.eq('fixture_id', filters.fixture);
   if (filters.tester)  q = q.eq('tester', filters.tester);
   if (filters.sn)      q = q.eq('board_id', filters.sn);
@@ -70,7 +71,7 @@ function applyFilters(query: any, start: string, end: string, filters: TestsFilt
     const escaped = filters.q.replace(/[%_]/g, '\\$&');
     q = q.or(
       [
-        `serial_number.ilike.%${escaped}%`,
+        `board_id.ilike.%${escaped}%`,
         `tester.ilike.%${escaped}%`,
         `fixture_id.ilike.%${escaped}%`,
         `operator_id.ilike.%${escaped}%`,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -495,7 +495,11 @@ export default function HomePage() {
   function handleReload() {
     if (!startDate || !endDate) return;
     void loadSummary(startDate, endDate, { product, fixture, sn, tester });
-    void loadPage(startDate, endDate, buildPageFilters(), page);
+    // Mirror the table effect logic: narrow range when a chart slice is selected
+    const effectiveStart = selectedDate && metric !== 'utilization' ? selectedDate : startDate;
+    const effectiveEnd   = selectedDate && metric !== 'utilization' ? selectedDate : endDate;
+    const testerOverride = metric === 'utilization' && selectedDate ? selectedDate : undefined;
+    void loadPage(effectiveStart, effectiveEnd, buildPageFilters({ tester: testerOverride ?? tester }), page);
   }
 
   return (


### PR DESCRIPTION
## Summary

Addresses all 4 review comments from PR #37:

- **P0**: Validate caller's JWT via `auth.getUser()` before running service-role summary queries in `/api/summary` — prevents unauthenticated access with fake `Authorization` headers
- **P1**: Add missing `product` filter to `applyFilters()` in `/api/tests` so authenticated queries respect the `?product=` parameter
- **P1**: Fix text search predicate from `serial_number.ilike` (doesn't exist on `tests` table) to `board_id.ilike`
- **P2**: `handleReload()` now respects `selectedDate` — narrows date range or applies tester filter to match the current chart drill-down state

## Test plan

- [x] All 155 tests pass (`npm test`)
- [x] Lint passes with 0 errors (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [ ] Verify `/api/summary` returns 401 for invalid JWT
- [ ] Verify `/api/tests?product=X` filters correctly for authenticated users
- [ ] Verify free-text search `?q=` works without PostgREST errors
- [ ] Verify reload button preserves chart slice context

https://claude.ai/code/session_014YvtLawxyQ5Z4DqwBFNyaV